### PR TITLE
Fix timespan/timestep constant shadowing (#83, #82); extend EulerLagrange ensembles (#64)

### DIFF
--- a/src/abc_flow.jl
+++ b/src/abc_flow.jl
@@ -17,8 +17,8 @@ module ABCFlow
 
     export odeproblem, odeensemble
 
-    const timespan = (0.0, 100.0)
-    const timestep = 0.1
+    const DEFAULT_TIMESPAN = (0.0, 100.0)
+    const DEFAULT_TIMESTEP = 0.1
 
     const default_parameters = (
         A = 0.5,
@@ -40,11 +40,11 @@ module ABCFlow
         nothing
     end
 
-    function odeproblem(q₀ = q₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function odeproblem(q₀ = q₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
         ODEProblem(abc_flow_v, timespan, timestep, q₀; parameters = parameters)
     end
 
-    function odeensemble(samples = [q₀, q₁, q₂]; parameters = default_parameters, timespan = timespan, timestep = timestep)
+    function odeensemble(samples = [q₀, q₁, q₂]; parameters = default_parameters, timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP)
         ODEEnsemble(abc_flow_v, timespan, timestep, samples; parameters = parameters)
     end
 

--- a/src/coupled_harmonic_oscillator.jl
+++ b/src/coupled_harmonic_oscillator.jl
@@ -33,8 +33,8 @@ module CoupledHarmonicOscillator
     export hodeensemble
     export hamiltonian_system, lagrangian_system
 
-    const timespan = (0.0, 100.0)
-    const timestep = 0.4
+    const DEFAULT_TIMESPAN = (0.0, 100.0)
+    const DEFAULT_TIMESTEP = 0.4
 
     const default_parameters = (
         m₁ = 2.,
@@ -94,17 +94,17 @@ module CoupledHarmonicOscillator
     hodeproblem(
         q₀ = $(q₀),
         p₀ = $(p₀);
-        timespan = $(timespan),
-        timestep = $(timestep),
+        timespan = $(DEFAULT_TIMESPAN),
+        timestep = $(DEFAULT_TIMESTEP),
         parameters = $(default_parameters)
     )
     ```
     """
-    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
         HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
-    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
         eqs = functions(hamiltonian_system(_parameters(parameters)))
         HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
@@ -117,13 +117,13 @@ module CoupledHarmonicOscillator
     lodeproblem(
         q₀ = $(q₀),
         p₀ = $(p₀);
-        timespan = $(timespan),
-        timestep = $(timestep),
+        timespan = $(DEFAULT_TIMESPAN),
+        timestep = $(DEFAULT_TIMESTEP),
         parameters = $(default_parameters)
     )
     ```
     """
-    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
         LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
     end
 

--- a/src/double_pendulum.jl
+++ b/src/double_pendulum.jl
@@ -132,7 +132,7 @@ module DoublePendulum
         p₀ = $(p₀);
         timespan = $(DEFAULT_TIMESPAN),
         timestep = $(DEFAULT_TIMESTEP),
-        params = $(default_parameters)
+        parameters = $(default_parameters)
     )
     ```
     """
@@ -156,7 +156,7 @@ module DoublePendulum
         p₀ = $(p₀);
         timespan = $(DEFAULT_TIMESPAN),
         timestep = $(DEFAULT_TIMESTEP),
-        params = $(default_parameters)
+        parameters = $(default_parameters)
     )
     ```
     """

--- a/src/double_pendulum.jl
+++ b/src/double_pendulum.jl
@@ -25,9 +25,12 @@ module DoublePendulum
     using EulerLagrange
     using LinearAlgebra
     using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
     export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
 
     ϑ₁(t, q, q̇, params) = (params.m₁ + params.m₂) * params.l₁^2 * q̇[1] + 
@@ -62,8 +65,8 @@ module DoublePendulum
     end
 
 
-    const timestep = 0.01
-    const timespan = (0.0, 10.0)
+    const DEFAULT_TIMESTEP = 0.01
+    const DEFAULT_TIMESPAN = (0.0, 10.0)
 
     const default_parameters = (
         l₁ = 2.0,
@@ -75,7 +78,7 @@ module DoublePendulum
 
     const θ₀ = [π/4, π/2]
     const ω₀ = [0.0, π/8]
-    const p₀ = ϑ(timespan[begin], θ₀, ω₀, default_parameters)
+    const p₀ = ϑ(DEFAULT_TIMESPAN[begin], θ₀, ω₀, default_parameters)
 
 
     function hamiltonian(t, q, p, params)
@@ -101,6 +104,23 @@ module DoublePendulum
               m₂  * l₂ * g * cos(q[2])
     end
 
+    function hamiltonian_system(parameters::NamedTuple)
+        t, q, p = hamiltonian_variables(2)
+        sparams = symbolize(parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(2)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
 
     """
         Hamiltonian problem for the double pendulum
@@ -110,17 +130,20 @@ module DoublePendulum
     hodeproblem(
         q₀ = [π/4, π/2],
         p₀ = $(p₀);
-        timespan = $(timespan),
-        timestep = $(timestep),
+        timespan = $(DEFAULT_TIMESPAN),
+        timestep = $(DEFAULT_TIMESTEP),
         params = $(default_parameters)
     )
     ```
     """
-    function hodeproblem(q₀ = θ₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, q, p = hamiltonian_variables(2)
-        sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+    function hodeproblem(q₀ = θ₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    "Hamiltonian ensemble for the double pendulum (varying initial conditions and/or parameters)."
+    function hodeensemble(q₀ = θ₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     """
@@ -131,17 +154,20 @@ module DoublePendulum
     lodeproblem(
         q₀ = [π/4, π/2],
         p₀ = $(p₀);
-        timespan = $(timespan),
-        timestep = $(timestep),
+        timespan = $(DEFAULT_TIMESPAN),
+        timestep = $(DEFAULT_TIMESTEP),
         params = $(default_parameters)
     )
     ```
     """
-    function lodeproblem(q₀ = θ₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(2)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; v̄ = θ̇, parameters = parameters)
+    function lodeproblem(q₀ = θ₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = θ̇, parameters = parameters)
+    end
+
+    "Lagrangian ensemble for the double pendulum (varying initial conditions and/or parameters)."
+    function lodeensemble(q₀ = θ₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; v̄ = θ̇, parameters = parameters)
     end
 
 end

--- a/src/duffing_oscillator.jl
+++ b/src/duffing_oscillator.jl
@@ -23,12 +23,15 @@ module DuffingOscillator
     using EulerLagrange
     using LinearAlgebra
     using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
     export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
-    const timespan = (0.0, 100.0)
-    const timestep = 0.1
+    const DEFAULT_TIMESPAN = (0.0, 100.0)
+    const DEFAULT_TIMESTEP = 0.1
 
     const default_parameters = (m = 1.0, α = 1.0, β = 1.0)
 
@@ -50,20 +53,43 @@ module DuffingOscillator
         nothing
     end
 
-    "Hamiltonian problem for the Duffing oscillator."
-    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function hamiltonian_system(parameters::NamedTuple)
         t, q, p = hamiltonian_variables(1)
         sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(1)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
+    "Hamiltonian problem for the Duffing oscillator."
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    "Hamiltonian ensemble for the Duffing oscillator (varying initial conditions and/or parameters)."
+    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     "Lagrangian problem for the Duffing oscillator."
-    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(1)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    end
+
+    "Lagrangian ensemble for the Duffing oscillator (varying initial conditions and/or parameters)."
+    function lodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
     end
 
 end

--- a/src/kubo_oscillator.jl
+++ b/src/kubo_oscillator.jl
@@ -43,7 +43,7 @@ module KuboOscillator
 
     const Δt = 0.01
     const nt = 10
-    const timespan = (0.0, Δt*nt)
+    const DEFAULT_TIMESPAN = (0.0, Δt*nt)
 
     const default_parameters = (ν = noise_intensity,)
 
@@ -69,20 +69,20 @@ module KuboOscillator
     end
 
 
-    function kubo_oscillator_sde_1(q₀=q_init_A; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_sde_1(q₀=q_init_A; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_A - interpreted as one random initial conditions with one sample path
         # 1-dimensional noise
         SDEProblem(kubo_oscillator_sde_v, kubo_oscillator_sde_B, KuboNoise(), timespan, timestep, q₀; parameters = parameters)
     end
 
-    function kubo_oscillator_sde_2(q₀=q_init_A; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_sde_2(q₀=q_init_A; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_A - single deterministic initial condition
         # Generating 3 sample paths
         # 1-dimensional noise
         SDEProblem(kubo_oscillator_sde_v, kubo_oscillator_sde_B, KuboNoise(), timespan, timestep, q₀; parameters = parameters)
     end
 
-    function kubo_oscillator_sde_3(q₀=q_init_B; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_sde_3(q₀=q_init_B; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_B holds several initial conditions -> ensemble problem
         equ = SDE(kubo_oscillator_sde_v, kubo_oscillator_sde_B, KuboNoise();
                   parameters = GeometricEquations.parameter_types(parameters))
@@ -93,7 +93,7 @@ module KuboOscillator
 
     # ODE
 
-    function kubo_oscillator_ode(q₀=q_init_A; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_ode(q₀=q_init_A; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         ODEProblem(kubo_oscillator_sde_v, timespan, timestep, q₀; parameters = parameters)
     end
 
@@ -126,7 +126,7 @@ module KuboOscillator
     end
 
 
-    function kubo_oscillator_psde_1(q₀=q_init_C, p₀=p_init_C; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_psde_1(q₀=q_init_C, p₀=p_init_C; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_C - interpreted as a single random initial condition with one sample path
         # 1-dimensional noise
         PSDEProblem(kubo_oscillator_psde_v, kubo_oscillator_psde_f,
@@ -134,7 +134,7 @@ module KuboOscillator
                     timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
-    function kubo_oscillator_psde_2(q₀=q_init_C, p₀=p_init_C; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_psde_2(q₀=q_init_C, p₀=p_init_C; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_C - single deterministic initial condition
         # Generating 3 sample paths
         # 1-dimensional noise
@@ -143,7 +143,7 @@ module KuboOscillator
                     timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
-    function kubo_oscillator_psde_3(q₀=q_init_D, p₀=p_init_D; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_psde_3(q₀=q_init_D, p₀=p_init_D; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_D / p_init_D hold several initial conditions -> ensemble problem
         equ = PSDE(kubo_oscillator_psde_v, kubo_oscillator_psde_f,
                    kubo_oscillator_psde_B, kubo_oscillator_psde_G, KuboNoise();
@@ -182,7 +182,7 @@ module KuboOscillator
     end
 
 
-    function kubo_oscillator_spsde_1(q₀ = q_init_C, p₀ = p_init_C; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_spsde_1(q₀ = q_init_C, p₀ = p_init_C; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_C - interpreted as a single random initial condition with one sample path
         # 1-dimensional noise
         SPSDEProblem(kubo_oscillator_spsde_v, kubo_oscillator_spsde_f1, kubo_oscillator_spsde_f2,
@@ -190,7 +190,7 @@ module KuboOscillator
                      timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
-    function kubo_oscillator_spsde_2(q₀ = q_init_C, p₀ = p_init_C; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_spsde_2(q₀ = q_init_C, p₀ = p_init_C; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_C - single deterministic initial condition
         # Generating 3 sample paths
         # 1-dimensional noise
@@ -199,7 +199,7 @@ module KuboOscillator
                      timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
-    function kubo_oscillator_spsde_3(q₀ = q_init_D, p₀ = p_init_D; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function kubo_oscillator_spsde_3(q₀ = q_init_D, p₀ = p_init_D; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         # q_init_D / p_init_D hold several initial conditions -> ensemble problem
         equ = SPSDE(kubo_oscillator_spsde_v, kubo_oscillator_spsde_f1, kubo_oscillator_spsde_f2,
                     kubo_oscillator_spsde_B, kubo_oscillator_spsde_G1, kubo_oscillator_spsde_G2, KuboNoise();

--- a/src/lennard_jones_oscillator.jl
+++ b/src/lennard_jones_oscillator.jl
@@ -22,12 +22,15 @@ module LennardJonesOscillator
     using EulerLagrange
     using LinearAlgebra
     using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
     export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
-    const timespan = (0.0, 10.0)
-    const timestep = 0.01
+    const DEFAULT_TIMESPAN = (0.0, 10.0)
+    const DEFAULT_TIMESTEP = 0.01
 
     const default_parameters = (m = 1.0, ε = 1.0, σ = 1.0)
 
@@ -52,20 +55,43 @@ module LennardJonesOscillator
         nothing
     end
 
-    "Hamiltonian problem for the Lennard-Jones oscillator."
-    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function hamiltonian_system(parameters::NamedTuple)
         t, q, p = hamiltonian_variables(1)
         sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(1)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
+    "Hamiltonian problem for the Lennard-Jones oscillator."
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    "Hamiltonian ensemble for the Lennard-Jones oscillator (varying initial conditions and/or parameters)."
+    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     "Lagrangian problem for the Lennard-Jones oscillator."
-    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(1)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    end
+
+    "Lagrangian ensemble for the Lennard-Jones oscillator (varying initial conditions and/or parameters)."
+    function lodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
     end
 
 end

--- a/src/linear_wave.jl
+++ b/src/linear_wave.jl
@@ -20,26 +20,26 @@ module LinearWave
     include("bump_initial_condition.jl")
 
     const μ̃ = .6
-    const Ñ = 256
+    const Ñ = 256
 
-    const default_parameters = (μ = μ̃, N = Ñ)
+    const default_parameters = (μ = μ̃, N = Ñ)
 
     function hamiltonian(t, q, p, parameters)
         @unpack N, μ = parameters
         
-        Δx = one(μ) / (Ñ + 1)
+        Δx = one(μ) / (Ñ + 1)
         Δx² = Δx ^ 2
         μ² = μ ^ 2
-        sum(p[n] ^ 2 for n in 1 : (Ñ + 2)) / 2 + μ² / 4Δx² * sum(((q[i] - q[i - 1]) ^ 2 + (q[i + 1] - q[i]) ^ 2) for i in 2 : (Ñ + 1))   
+        sum(p[n] ^ 2 for n in 1 : (Ñ + 2)) / 2 + μ² / 4Δx² * sum(((q[i] - q[i - 1]) ^ 2 + (q[i + 1] - q[i]) ^ 2) for i in 2 : (Ñ + 1))   
     end
 
     function lagrangian(t, q, q̇, parameters)
         @unpack N, μ = parameters 
 
-        Δx = one(μ) / (Ñ + 1)
+        Δx = one(μ) / (Ñ + 1)
         Δx² = Δx ^ 2 
         μ² = μ ^ 2
-        sum(q̇[n] ^ 2 for n in 1 : (Ñ + 2)) / 2 - μ² / 4Δx² * sum(((q[i] - q[i - 1]) ^ 2 + (q[i + 1] - q[i]) ^ 2) for i in 2 : (Ñ + 1))
+        sum(q̇[n] ^ 2 for n in 1 : (Ñ + 2)) / 2 - μ² / 4Δx² * sum(((q[i] - q[i - 1]) ^ 2 + (q[i + 1] - q[i]) ^ 2) for i in 2 : (Ñ + 1))
     end
 
     _timestep(timespan::Tuple, n_time_steps::Integer) = (timespan[2] - timespan[1]) / (n_time_steps-1)
@@ -49,8 +49,8 @@ module LinearWave
     const n_time_steps = 200
     const DEFAULT_TIMESTEP = _timestep(DEFAULT_TIMESPAN, n_time_steps)
 
-    const q₀ = compute_initial_condition2(μ̃, Ñ + 2).q 
-    const p₀ = compute_initial_condition2(μ̃, Ñ + 2).p 
+    const q₀ = compute_initial_condition2(μ̃, Ñ + 2).q 
+    const p₀ = compute_initial_condition2(μ̃, Ñ + 2).p 
 
     function hamiltonian_system(parameters::NamedTuple)
         t, q, p = hamiltonian_variables(Ñ + 2)

--- a/src/linear_wave.jl
+++ b/src/linear_wave.jl
@@ -8,11 +8,14 @@ The only system parameters are the *number of points* ``N`` for which the system
 module LinearWave 
 
     using EulerLagrange
-    using LinearAlgebra 
-    using Parameters 
+    using LinearAlgebra
+    using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
-    export hodeproblem, lodeproblem  
+    export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
     include("bump_initial_condition.jl")
 
@@ -42,31 +45,58 @@ module LinearWave
     _timestep(timespan::Tuple, n_time_steps::Integer) = (timespan[2] - timespan[1]) / (n_time_steps-1)
 
 
-    const timespan = (0, 1)
+    const DEFAULT_TIMESPAN = (0, 1)
     const n_time_steps = 200
-    const timestep = _timestep(timespan, n_time_steps)
+    const DEFAULT_TIMESTEP = _timestep(DEFAULT_TIMESPAN, n_time_steps)
 
     const q₀ = compute_initial_condition2(μ̃, Ñ + 2).q 
     const p₀ = compute_initial_condition2(μ̃, Ñ + 2).p 
 
+    function hamiltonian_system(parameters::NamedTuple)
+        t, q, p = hamiltonian_variables(Ñ + 2)
+        sparams = symbolize(parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams; simplify = false)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(Ñ + 2)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams; simplify = false)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
     """
     Hamiltonian problem for the linear wave equation.
     """
-    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, q, p = hamiltonian_variables(Ñ + 2)
-        sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams; simplify = false)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    """
+    Hamiltonian ensemble for the linear wave equation (varying initial conditions and/or parameters).
+    """
+    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     """
     Lagrangian problem for the linear wave equation.
     """
-    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(Ñ + 2)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams; simplify = false)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    """
+    Lagrangian ensemble for the linear wave equation (varying initial conditions and/or parameters).
+    """
+    function lodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
 end

--- a/src/lorenz_attractor.jl
+++ b/src/lorenz_attractor.jl
@@ -29,7 +29,7 @@ module LorenzAttractor
 
     const Δt = 0.01
     const nt = 1000
-    const timespan = (0.0, Δt*nt)
+    const DEFAULT_TIMESPAN = (0.0, Δt*nt)
 
     const q₀ = [1., 1., 1.]
 
@@ -45,7 +45,7 @@ module LorenzAttractor
     end
 
 
-    function lorenz_attractor_ode(q₀=q₀; timespan = timespan, timestep = Δt, parameters = default_parameters)
+    function lorenz_attractor_ode(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = Δt, parameters = default_parameters)
         ODEProblem(lorenz_attractor_v, timespan, timestep, q₀; parameters = parameters)
     end
 

--- a/src/lotka_volterra_2d.jl
+++ b/src/lotka_volterra_2d.jl
@@ -94,7 +94,7 @@ end
 # end
 
 
-function iodeproblem_dg_gauge(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=timespan, timestep=Δt, parameters=default_parameters, κ=0)
+function iodeproblem_dg_gauge(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters, κ=0)
     lotka_volterra_2d_ϑ = (p, t, q, v, params) -> lotka_volterra_2d_ϑ_κ(p, t, q, v, params, κ)
     lotka_volterra_2d_f = (f, t, q, v, params) -> lotka_volterra_2d_f_κ(f, t, q, v, params, κ)
     lotka_volterra_2d_g = (g, t, q, λ, params) -> lotka_volterra_2d_g_κ(g, t, q, λ, params, κ)

--- a/src/lotka_volterra_2d_equations.jl
+++ b/src/lotka_volterra_2d_equations.jl
@@ -17,12 +17,12 @@ export compute_energy_error
 
 const Δt = 0.01
 const nt = 1000
-const timespan = (0.0, Δt*nt)
+const DEFAULT_TIMESPAN = (0.0, Δt*nt)
 
 const default_parameters = (a₁=-1.0, a₂=-1.0, b₁=1.0, b₂=2.0)
 const reference_solution = [2.576489958858641, 1.5388112243762107]
 
-const t₀ = timespan[begin]
+const t₀ = DEFAULT_TIMESPAN[begin]
 const q₀ = [2.0, 1.0]
 const v₀ = [v₁(0, q₀, default_parameters), v₂(0, q₀, default_parameters)]
 
@@ -60,44 +60,44 @@ compute_energy_error(t,q,params) = compute_invariant_error(t,q, (t,q) -> hamilto
 
 
 "Creates an ODE object for the Lotka-Volterra 2D model."
-function odeproblem(q₀=q₀; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     ODEProblem(lotka_volterra_2d_v, timespan, timestep, q₀; parameters=parameters, invariants=(h=hamiltonian,))
 end
 
 "Creates a Hamiltonian ODE object for the Lotka-Volterra 2D model."
-function hodeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function hodeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     HODEProblem(lotka_volterra_2d_v, lotka_volterra_2d_f, hamiltonian_pode, timespan, timestep, q₀, p₀;
                 parameters=parameters)
 end
 
 "Creates an implicit ODE object for the Lotka-Volterra 2D model."
-function iodeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function iodeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     IODEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f,
                 lotka_volterra_2d_g, timespan, timestep, q₀, p₀;
                 parameters=parameters, invariants=(h=hamiltonian_iode,), v̄=lotka_volterra_2d_v)
 end
 
 "Creates a partitioned ODE object for the Lotka-Volterra 2D model."
-function podeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function podeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     PODEProblem(lotka_volterra_2d_v, lotka_volterra_2d_f, timespan, timestep, q₀, p₀;
                 parameters=parameters, invariants=(h=hamiltonian_pode,))
 end
 
 "Creates a variational ODE object for the Lotka-Volterra 2D model."
-function lodeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function lodeproblem(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     LODEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f,
                 lotka_volterra_2d_g, lagrangian, lotka_volterra_2d_ω, timespan, timestep, q₀, p₀;
                 parameters=parameters, invariants=(h=hamiltonian_iode,), v̄=lotka_volterra_2d_v)
 end
 
 "Creates a DAE object for the Lotka-Volterra 2D model."
-function daeproblem(q₀=vcat(q₀,v₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function daeproblem(q₀=vcat(q₀,v₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     DAEProblem(lotka_volterra_2d_v_dae, lotka_volterra_2d_u_dae, lotka_volterra_2d_ϕ_dae, timespan, timestep, q₀, λ₀;
                 parameters=parameters, invariants=(h=hamiltonian,))
 end
 
 "Creates a Hamiltonian DAE object for the Lotka-Volterra 2D model."
-function hdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function hdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     HDAEProblem(lotka_volterra_2d_v, lotka_volterra_2d_f,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
                 lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ,
@@ -105,7 +105,7 @@ function hdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=
 end
 
 "Creates an implicit DAE object for the Lotka-Volterra 2D model."
-function idaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function idaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     IDAEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
                 timespan, timestep, q₀, p₀, λ₀; parameters=parameters, invariants=(h=hamiltonian_iode,),
@@ -113,7 +113,7 @@ function idaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=
 end
 
 "Creates an implicit DAE object for the Lotka-Volterra 2D model."
-function idaeproblem_spark(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function idaeproblem_spark(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     IDAEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f_ham,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
                 timespan, timestep, q₀, p₀, λ₀; parameters=parameters, invariants=(h=hamiltonian_iode,),
@@ -121,7 +121,7 @@ function idaeproblem_spark(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); tim
 end
 
 "Creates a partitioned DAE object for the Lotka-Volterra 2D model."
-function pdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function pdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     PDAEProblem(lotka_volterra_2d_v_ham, lotka_volterra_2d_f_ham,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
                 timespan, timestep, q₀, p₀, λ₀; parameters=parameters, invariants=(h=hamiltonian_pode,),
@@ -129,7 +129,7 @@ function pdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=
 end
 
 "Creates a variational DAE object for the Lotka-Volterra 2D model."
-function ldaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function ldaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     LDAEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f_ham,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
                 lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ_lode,
@@ -139,7 +139,7 @@ function ldaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=
 end
 
 "Creates a variational DAE object for the Lotka-Volterra 2D model for use with SLRK integrators."
-function ldaeproblem_slrk(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function ldaeproblem_slrk(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     LDAEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
                 lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ,
@@ -149,7 +149,7 @@ function ldaeproblem_slrk(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); time
 end
 
 "Creates an implicit ODE object for the Lotka-Volterra 2D model for use with DG integrators."
-function iodeproblem_dg(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function iodeproblem_dg(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     IODEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f, lotka_volterra_2d_g,
                 timespan, timestep, q₀, p₀; parameters=parameters, invariants=(h=hamiltonian_iode,), v̄=lotka_volterra_2d_v)
 end

--- a/src/lotka_volterra_3d.jl
+++ b/src/lotka_volterra_3d.jl
@@ -54,7 +54,7 @@ export compute_energy_error, compute_casimir_error
 
 const Δt = 0.01
 const nt = 1000
-const timespan = (0.0, Δt * nt)
+const DEFAULT_TIMESPAN = (0.0, Δt * nt)
 
 const default_parameters = (A1=1.0, A2=1.0, A3=1.0, B1=0.0, B2=1.0, B3=1.0)
 const reference_solution = [1.2429313310230237, 2.263720576035246, 0.7108206593932]
@@ -103,7 +103,7 @@ function lotka_volterra_3d_v(v, t, q, params)
 end
 
 
-function odeproblem(q₀=q₀; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     ODEProblem(lotka_volterra_3d_v, timespan, timestep, q₀; parameters=parameters, invariants=(h=hamiltonian,))
 end
 

--- a/src/lotka_volterra_4d.jl
+++ b/src/lotka_volterra_4d.jl
@@ -34,7 +34,7 @@ export odeproblem,
 
 const Δt = 0.01
 const nt = 1000
-const timespan = (0.0, Δt * nt)
+const DEFAULT_TIMESPAN = (0.0, Δt * nt)
 
 const q₀ = [2.0, 1.0, 1.0, 1.0]
 
@@ -370,25 +370,25 @@ end
 lotka_volterra_4d_ψ(ψ, t, q, v, p, q̇, ṗ, params) = lotka_volterra_4d_ψ(ψ, t, q, p, q̇, ṗ, params)
 
 
-function odeproblem(q₀=q₀; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     ODEProblem(lotka_volterra_4d_v, timespan, timestep, q₀; parameters=parameters, invariants=(h=hamiltonian,))
 end
 
 
-function podeproblem(q₀=q₀, p₀=nothing; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function podeproblem(q₀=q₀, p₀=nothing; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     PODEProblem(lotka_volterra_4d_v, lotka_volterra_4d_f,
         timespan, timestep, q₀, p₀; parameters=parameters, invariants=(h=hamiltonian,))
 end
 
-function iodeproblem(q₀=q₀, p₀=nothing; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function iodeproblem(q₀=q₀, p₀=nothing; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     IODEProblem(lotka_volterra_4d_ϑ, lotka_volterra_4d_f,
         lotka_volterra_4d_g, timespan, timestep, q₀, p₀;
         parameters=parameters, invariants=(h=hamiltonian,), v̄=lotka_volterra_4d_v)
 end
 
-function lodeproblem(q₀=q₀, p₀=nothing; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function lodeproblem(q₀=q₀, p₀=nothing; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     LODEProblem(lotka_volterra_4d_ϑ, lotka_volterra_4d_f,
         lotka_volterra_4d_g, lotka_volterra_4d_ω,
@@ -396,7 +396,7 @@ function lodeproblem(q₀=q₀, p₀=nothing; timespan=timespan, timestep=Δt, p
         parameters=parameters, invariants=(h=hamiltonian,), v̄=lotka_volterra_4d_v)
 end
 
-function idaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function idaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     IDAEProblem(lotka_volterra_4d_ϑ, lotka_volterra_4d_f,
         lotka_volterra_4d_u, lotka_volterra_4d_g, lotka_volterra_4d_ϕ,
@@ -405,7 +405,7 @@ function idaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespa
         parameters=parameters, invariants=(h=hamiltonian,), v̄=lotka_volterra_4d_v)
 end
 
-function pdaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function pdaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     PDAEProblem(lotka_volterra_4d_v, lotka_volterra_4d_f,
         lotka_volterra_4d_u, lotka_volterra_4d_g, lotka_volterra_4d_ϕ,
@@ -415,7 +415,7 @@ function pdaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespa
         parameters=parameters, invariants=(h=hamiltonian,))
 end
 
-function pdaeproblem_secondary(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function pdaeproblem_secondary(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     PDAEProblem(lotka_volterra_4d_v_ham, lotka_volterra_4d_f_ham,
         lotka_volterra_4d_u, lotka_volterra_4d_g, lotka_volterra_4d_ϕ,
@@ -425,7 +425,7 @@ function pdaeproblem_secondary(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timesp
         parameters=parameters, invariants=(h=hamiltonian,))
 end
 
-function ldaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function ldaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     LDAEProblem(lotka_volterra_4d_ϑ, lotka_volterra_4d_f,
         lotka_volterra_4d_u, lotka_volterra_4d_g, lotka_volterra_4d_ϕ,
@@ -435,7 +435,7 @@ function ldaeproblem(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespa
         v̄=lotka_volterra_4d_v, f̄=lotka_volterra_4d_f,)
 end
 
-function ldaeproblem_secondary(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=timespan, timestep=Δt, parameters=default_parameters)
+function ldaeproblem_secondary(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     LDAEProblem(lotka_volterra_4d_ϑ, lotka_volterra_4d_f_ham,
         lotka_volterra_4d_u, lotka_volterra_4d_g, lotka_volterra_4d_ϕ,
@@ -445,7 +445,7 @@ function ldaeproblem_secondary(q₀=q₀, p₀=nothing, λ₀=zero(q₀); timesp
         v̄=lotka_volterra_4d_v, f̄=lotka_volterra_4d_f,)
 end
 
-function iodeproblem_dg(q₀=q₀, p₀=nothing; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function iodeproblem_dg(q₀=q₀, p₀=nothing; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     p₀ === nothing ? p₀ = ϑ(timespan[begin], q₀) : nothing
     IODEProblem(lotka_volterra_4d_ϑ, lotka_volterra_4d_f,
         lotka_volterra_4d_g, timespan, timestep, q₀, p₀;

--- a/src/lotka_volterra_4d_lagrangian.jl
+++ b/src/lotka_volterra_4d_lagrangian.jl
@@ -29,7 +29,7 @@ export lotka_volterra_4d_ode,
 
 const Δt = 0.01
 const nt = 1000
-const timespan = (0.0, Δt * nt)
+const DEFAULT_TIMESPAN = (0.0, Δt * nt)
 
 const q₀ = [2.0, 1.0, 1.0, 1.0]
 
@@ -107,18 +107,18 @@ function initial_momentum(lag_sys, t₀, q₀, params)
 end
 
 
-function odeproblem(q₀=q₀, A=A_default, B=B_default; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function odeproblem(q₀=q₀, A=A_default, B=B_default; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     lag_sys = lagrangian_system(A, B, parameters)
     ODEProblem(lag_sys, timespan, timestep, q₀; parameters=parameters)
 end
 
-function lodeproblem(q₀=q₀, A=A_default, B=B_default; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function lodeproblem(q₀=q₀, A=A_default, B=B_default; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     lag_sys = lagrangian_system(A, B, parameters)
     p₀ = initial_momentum(lag_sys, timespan[begin], q₀, parameters)
     LODEProblem(lag_sys, timespan, timestep, q₀, p₀; parameters=parameters)
 end
 
-function ldaeproblem(q₀=q₀, A=A_default, B=B_default; timespan=timespan, timestep=Δt, parameters=default_parameters)
+function ldaeproblem(q₀=q₀, A=A_default, B=B_default; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters=default_parameters)
     lag_sys = lagrangian_system(A, B, parameters)
     p₀ = initial_momentum(lag_sys, timespan[begin], q₀, parameters)
     LDAEProblem(lag_sys, timespan, timestep, q₀, p₀, zero(q₀); parameters=parameters)

--- a/src/massless_charged_particle.jl
+++ b/src/massless_charged_particle.jl
@@ -46,7 +46,7 @@ module MasslessChargedParticle
     # default simulation parameters
     const Δt = 0.2
     const nt = 5000
-    const timespan = (0.0, Δt*nt)
+    const DEFAULT_TIMESPAN = (0.0, Δt*nt)
 
     # default initial conditions and parameters
     q₀ = [1.0, 1.0]
@@ -181,12 +181,12 @@ module MasslessChargedParticle
 
 
     "Creates an ODE object for the massless charged particle in 2D."
-    function odeproblem(q₀=q₀; timespan=timespan, timestep=Δt, parameters = default_parameters)
+    function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters = default_parameters)
         ODEProblem(massless_charged_particle_v, timespan, timestep, q₀; invariants=(h=hamiltonian,), parameters=parameters)
     end
 
     "Creates an implicit ODE object for the massless charged particle in 2D."
-    function iodeproblem(q₀=q₀; timespan=timespan, timestep=Δt, parameters = default_parameters)
+    function iodeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters = default_parameters)
         IODEProblem(massless_charged_particle_ϑ, massless_charged_particle_f,
                 massless_charged_particle_g,
                 timespan, timestep, q₀, ϑ(0., q₀, parameters);
@@ -195,7 +195,7 @@ module MasslessChargedParticle
     end
 
     "Creates an implicit DAE object for the massless charged particle in 2D."
-    function idaeproblem(q₀=q₀; timespan=timespan, timestep=Δt, parameters = default_parameters)
+    function idaeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters = default_parameters)
         IDAEProblem(massless_charged_particle_ϑ, massless_charged_particle_f,
                 massless_charged_particle_u, massless_charged_particle_g,
                 massless_charged_particle_ϕ,
@@ -205,7 +205,7 @@ module MasslessChargedParticle
     end
 
     "Creates an implicit DAE object for the massless charged particle in 2D."
-    function idaeproblem_spark(q₀=q₀; timespan=timespan, timestep=Δt, parameters = default_parameters)
+    function idaeproblem_spark(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=Δt, parameters = default_parameters)
         IDAEProblem(massless_charged_particle_ϑ, massless_charged_particle_f̄,
                 massless_charged_particle_u, massless_charged_particle_g,
                 massless_charged_particle_ϕ,

--- a/src/mathews_lakshmanan_oscillator.jl
+++ b/src/mathews_lakshmanan_oscillator.jl
@@ -23,12 +23,15 @@ module MathewsLakshmananOscillator
     using EulerLagrange
     using LinearAlgebra
     using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
     export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
-    const timespan = (0.0, 20.0)
-    const timestep = 0.01
+    const DEFAULT_TIMESPAN = (0.0, 20.0)
+    const DEFAULT_TIMESTEP = 0.01
 
     const default_parameters = (ω = 1.0, λ = 1.0)
 
@@ -50,20 +53,43 @@ module MathewsLakshmananOscillator
         nothing
     end
 
-    "Hamiltonian problem for the Mathews-Lakshmanan oscillator."
-    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function hamiltonian_system(parameters::NamedTuple)
         t, q, p = hamiltonian_variables(1)
         sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(1)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
+    "Hamiltonian problem for the Mathews-Lakshmanan oscillator."
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    "Hamiltonian ensemble for the Mathews-Lakshmanan oscillator (varying initial conditions and/or parameters)."
+    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     "Lagrangian problem for the Mathews-Lakshmanan oscillator."
-    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(1)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    end
+
+    "Lagrangian ensemble for the Mathews-Lakshmanan oscillator (varying initial conditions and/or parameters)."
+    function lodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
     end
 
 end

--- a/src/morse_oscillator.jl
+++ b/src/morse_oscillator.jl
@@ -23,12 +23,15 @@ module MorseOscillator
     using EulerLagrange
     using LinearAlgebra
     using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
     export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
-    const timespan = (0.0, 20.0)
-    const timestep = 0.01
+    const DEFAULT_TIMESPAN = (0.0, 20.0)
+    const DEFAULT_TIMESTEP = 0.01
 
     const default_parameters = (m = 1.0, D = 1.0, a = 1.0, r₀ = 0.0)
 
@@ -52,20 +55,43 @@ module MorseOscillator
         nothing
     end
 
-    "Hamiltonian problem for the Morse oscillator."
-    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function hamiltonian_system(parameters::NamedTuple)
         t, q, p = hamiltonian_variables(1)
         sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(1)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
+    "Hamiltonian problem for the Morse oscillator."
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    "Hamiltonian ensemble for the Morse oscillator (varying initial conditions and/or parameters)."
+    function hodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     "Lagrangian problem for the Morse oscillator."
-    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(1)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    end
+
+    "Lagrangian ensemble for the Morse oscillator (varying initial conditions and/or parameters)."
+    function lodeensemble(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
     end
 
 end

--- a/src/point_vortices.jl
+++ b/src/point_vortices.jl
@@ -23,7 +23,7 @@ module PointVortices
 
     const Δt = 0.01
     const nt = 1000
-    const timespan = (0.0, Δt*nt)
+    const DEFAULT_TIMESPAN = (0.0, Δt*nt)
     
     const reference_solution = [0.18722529318641928, 0.38967432450068706, 0.38125332930294187, 0.4258020604293123]
 
@@ -232,30 +232,30 @@ module PointVortices
     point_vortices_ϕ(ϕ, t, q, v, p, params) = point_vortices_ϕ(ϕ, t, q, p, params)
 
 
-    function odeproblem(q₀=q₀; timespan = timespan, timestep = Δt)
+    function odeproblem(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = Δt)
         ODEProblem(point_vortices_v, timespan, timestep, q₀)
     end
 
-    function iodeproblem(q₀=q₀, p₀=ϑ(q₀); timespan = timespan, timestep = Δt)
+    function iodeproblem(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = Δt)
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, p₀;
                     v̄=point_vortices_v)
     end
 
-    function idaeproblem(q₀=q₀, p₀=ϑ(q₀), λ₀=zero(q₀); timespan = timespan, timestep = Δt)
+    function idaeproblem(q₀=q₀, p₀=ϑ(q₀), λ₀=zero(q₀); timespan = DEFAULT_TIMESPAN, timestep = Δt)
         IDAEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_u, point_vortices_g,
                     point_vortices_ϕ, timespan, timestep, q₀, p₀, λ₀;
                     v̄=point_vortices_v)
     end
 
-    function idoeproblem_dg(q₀=q₀; timespan = timespan, timestep = Δt)
+    function idoeproblem_dg(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = Δt)
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, q₀;
                     v=point_vortices_v)
     end
 
-    function lodeproblem_formal_lagrangian(q₀=q₀, p₀=ϑ(q₀); timespan = timespan, timestep = Δt)
+    function lodeproblem_formal_lagrangian(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = Δt)
         LODEProblem(ϑ, point_vortices_f, point_vortices_g, timespan, timestep, q₀, p₀;
                     v̄=point_vortices_v, Ω=ω, ∇H=dH)
     end

--- a/src/point_vortices_linear.jl
+++ b/src/point_vortices_linear.jl
@@ -18,7 +18,7 @@ module PointVorticesLinear
 
     const Δt = 0.01
     const nt = 1000
-    const timespan = (0.0, Δt*nt)
+    const DEFAULT_TIMESPAN = (0.0, Δt*nt)
     
     const γ₁ = 4.0
     const γ₂ = 2.0
@@ -123,7 +123,7 @@ module PointVorticesLinear
         nothing
     end
 
-    function odeproblem(q₀=q₀; timespan = timespan, timestep = Δt)
+    function odeproblem(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = Δt)
         ODEProblem(point_vortices_v, timespan, timestep, q₀)
     end
 
@@ -159,19 +159,19 @@ module PointVorticesLinear
         point_vortices_v(v, t, q, params)
     end
 
-    function iodeproblem(q₀=q₀, p₀=ϑ(q₀); timespan = timespan, timestep = Δt)
+    function iodeproblem(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = Δt)
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, p₀;
                     v̄=point_vortices_v)
     end
 
-    function iodeproblem_dg(q₀=q₀; timespan = timespan, timestep = Δt)
+    function iodeproblem_dg(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = Δt)
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, q₀;
                     v=point_vortices_v)
     end
 
-    function lodeproblem_formal_lagrangian(q₀=q₀, p₀=ϑ(q₀); timespan = timespan, timestep = Δt)
+    function lodeproblem_formal_lagrangian(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = Δt)
         LODEProblem(ϑ, point_vortices_f, point_vortices_g, timespan, timestep, q₀, p₀;
                     v̄=point_vortices_v, Ω=ω, ∇H=dH)
     end

--- a/src/rigid_body.jl
+++ b/src/rigid_body.jl
@@ -21,8 +21,8 @@ module RigidBody
 
     export odeproblem, odeensemble
 
-    const timespan = (0.0, 100.0)
-    const timestep = 0.1
+    const DEFAULT_TIMESPAN = (0.0, 100.0)
+    const DEFAULT_TIMESTEP = 0.1
 
     const default_parameters = (
         I₁ = 2.,
@@ -46,11 +46,11 @@ module RigidBody
         nothing
     end
 
-    function odeproblem(q₀ = q₀; timespan = timespan, timestep = timestep, parameters = default_parameters)
+    function odeproblem(q₀ = q₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
         ODEProblem(rigid_body_v, timespan, timestep, q₀; parameters = parameters)
     end
 
-    function odeensemble(samples = [q₀, q₁, q₂]; parameters = default_parameters, timespan = timespan, timestep = timestep)
+    function odeensemble(samples = [q₀, q₁, q₂]; parameters = default_parameters, timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP)
         ODEEnsemble(rigid_body_v, timespan, timestep, samples; parameters = parameters)
     end
 

--- a/src/three_body_problem.jl
+++ b/src/three_body_problem.jl
@@ -12,9 +12,12 @@ module ThreeBody
     using EulerLagrange
     using LinearAlgebra
     using Parameters
+    using GeometricEquations: HODEEnsemble, LODEEnsemble
 
     export hamiltonian, lagrangian
     export hodeproblem, lodeproblem
+    export hodeensemble, lodeensemble
+    export hamiltonian_system, lagrangian_system
 
     "Turn array into a vector."
     _reshape(arr::AbstractArray) = reshape(arr, length(arr))
@@ -40,10 +43,10 @@ module ThreeBody
     const G = 1.
 
     @doc raw"Constant taken from [jin2020sympnets](@cite)."
-    const timestep = .5
+    const DEFAULT_TIMESTEP = .5
 
     @doc raw"Range is taken from [jin2020sympnets](@cite). In that reference the integration is only done for ten time steps."
-    const timespan = (0.0, 10 * timestep)
+    const DEFAULT_TIMESPAN = (0.0, 10 * DEFAULT_TIMESTEP)
 
     @doc raw"Default parameters taken from [jin2020sympnets](@cite)."
     const default_parameters = (
@@ -79,6 +82,23 @@ module ThreeBody
         nothing
     end
 
+    function hamiltonian_system(parameters::NamedTuple)
+        t, q, p = hamiltonian_variables(6)
+        sparams = symbolize(parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(6)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    # Build the symbolic system from a single parameter set, while a vector of parameter
+    # sets is passed on to the ensemble unchanged (see issue #64).
+    _parameters(p::NamedTuple) = p
+    _parameters(p::AbstractVector) = p[begin]
+
 
     """
         hodeproblem(q₀, p₀; timespan, timestep, parameters)
@@ -90,17 +110,20 @@ module ThreeBody
     hodeproblem(
         q₀ = $(initial_condition.q),
         p₀ = $(initial_condition.p);
-        timespan = $(timespan),
-        timestep = $(timestep),
+        timespan = $(DEFAULT_TIMESPAN),
+        timestep = $(DEFAULT_TIMESTEP),
         params = $(default_parameters)
     )
     ```
     """
-    function hodeproblem(q₀ = initial_condition.q, p₀ = initial_condition.p; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, q, p = hamiltonian_variables(6)
-        sparams = symbolize(parameters)
-        ham_sys = HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
-        HODEProblem(ham_sys, timespan, timestep, q₀, p₀; parameters = parameters)
+    function hodeproblem(q₀ = initial_condition.q, p₀ = initial_condition.p; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    "Hamiltonian ensemble for the three-body problem (varying initial conditions and/or parameters)."
+    function hodeensemble(q₀ = initial_condition.q, p₀ = initial_condition.p; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(hamiltonian_system(_parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters = parameters)
     end
 
     """
@@ -113,17 +136,20 @@ module ThreeBody
     lodeproblem(
         q₀ = $(initial_condition.q),
         p₀ = $(initial_condition.p);
-        timespan = $(timespan),
-        timestep = $(timestep),
+        timespan = $(DEFAULT_TIMESPAN),
+        timestep = $(DEFAULT_TIMESTEP),
         params = $(default_parameters)
     )
     ```
     """
-    function lodeproblem(q₀ = initial_condition.q, p₀ = initial_condition.p; timespan = timespan, timestep = timestep, parameters = default_parameters)
-        t, x, v = lagrangian_variables(6)
-        sparams = symbolize(parameters)
-        lag_sys = LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
-        LODEProblem(lag_sys, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    function lodeproblem(q₀ = initial_condition.q, p₀ = initial_condition.p; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
+    end
+
+    "Lagrangian ensemble for the three-body problem (varying initial conditions and/or parameters)."
+    function lodeensemble(q₀ = initial_condition.q, p₀ = initial_condition.p; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters)
+        eqs = functions(lagrangian_system(_parameters(parameters)))
+        LODEEnsemble(eqs.ϑ, eqs.f, eqs.g, eqs.ω, eqs.L, timespan, timestep, q₀, p₀; v̄ = v̄, parameters = parameters)
     end
 
 end

--- a/src/three_body_problem.jl
+++ b/src/three_body_problem.jl
@@ -112,7 +112,7 @@ module ThreeBody
         p₀ = $(initial_condition.p);
         timespan = $(DEFAULT_TIMESPAN),
         timestep = $(DEFAULT_TIMESTEP),
-        params = $(default_parameters)
+        parameters = $(default_parameters)
     )
     ```
     """
@@ -138,7 +138,7 @@ module ThreeBody
         p₀ = $(initial_condition.p);
         timespan = $(DEFAULT_TIMESPAN),
         timestep = $(DEFAULT_TIMESTEP),
-        params = $(default_parameters)
+        parameters = $(default_parameters)
     )
     ```
     """

--- a/src/toda_lattice.jl
+++ b/src/toda_lattice.jl
@@ -28,8 +28,8 @@ end
 hamiltonian(t, q, p, params, N) = p ⋅ p / 2 + potential(q, params, N)
 lagrangian(t, q, q̇, params, N) = q̇ ⋅ q̇ / 2 - potential(q, params, N)
 
-const timestep = 0.1
-const timespan = (0.0, 120.0)
+const DEFAULT_TIMESTEP = 0.1
+const DEFAULT_TIMESPAN = (0.0, 120.0)
 
 # parameter for the default initial conditions
 const Ñ = 200
@@ -61,7 +61,7 @@ _length(q::AbstractVector{<:AbstractArray}) = length(q[begin])
 """
 Hamiltonian problem for the Toda lattice.
 """
-function hodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=timespan, timestep=timestep, parameters=default_parameters)
+function hodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters)
     HODEProblem(hamiltonian_system(N, parameters), timespan, timestep, q₀, p₀; parameters=parameters)
 end
 
@@ -70,7 +70,7 @@ function hodeproblem(q₀, p₀; kwargs...)
     hodeproblem(length(q₀), q₀, p₀; kwargs...)
 end
 
-function hodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=timespan, timestep=timestep, parameters=default_parameters)
+function hodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters)
     eqs = functions(hamiltonian_system(N, _parameters(parameters)))
     HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters=parameters)
 end
@@ -83,7 +83,7 @@ end
 """
 Lagrangian problem for the Toda lattice.
 """
-function lodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=timespan, timestep=timestep, parameters=default_parameters)
+function lodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters)
     heqs = functions(hamiltonian_system(N, _parameters(parameters)))
     LODEProblem(lagrangian_system(N, parameters), timespan, timestep, q₀, p₀; parameters=parameters, v̄=heqs.v)
 end
@@ -93,7 +93,7 @@ function lodeproblem(q₀, p₀; kwargs...)
     lodeproblem(length(q₀), q₀, p₀; kwargs...)
 end
 
-function lodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=timespan, timestep=timestep, parameters=default_parameters)
+function lodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters)
     leqs = functions(lagrangian_system(N, _parameters(parameters)))
     heqs = functions(hamiltonian_system(N, _parameters(parameters)))
     LODEEnsemble(leqs.ϑ, leqs.f, leqs.g, leqs.ω, leqs.L, timespan, timestep, q₀, p₀; parameters=parameters, v̄=heqs.v)

--- a/test/default_timespan_timestep_tests.jl
+++ b/test/default_timespan_timestep_tests.jl
@@ -1,0 +1,64 @@
+using Test
+using GeometricProblems
+# GeometricEquations re-exports GeometricBase.timespan / .timestep; use it here because
+# GeometricBase is not a direct test dependency.
+using GeometricEquations: timespan, timestep
+
+# Regression tests for issues #83 and #82.
+#
+# PR #81 mistakenly renamed the module-level default constants `tspan`/`tstep` to
+# `timespan`/`timestep`, which shadowed the `GeometricBase.timespan` /
+# `GeometricBase.timestep` functions inside the problem modules (issue #83). The
+# fix renames those constants to `DEFAULT_TIMESPAN` / `DEFAULT_TIMESTEP`. These
+# tests guard against a regression: in every problem module the names
+# `timespan`/`timestep` must still resolve to the GeometricBase functions (never a
+# shadowing constant), and the default values must live in `DEFAULT_TIMESPAN` /
+# `DEFAULT_TIMESTEP`.
+
+# All problem modules that define default-timespan/timestep constants.
+const PROBLEM_MODULES = (
+    :ABCFlow,
+    :CoupledHarmonicOscillator,
+    :DoublePendulum,
+    :DuffingOscillator,
+    :KuboOscillator,
+    :LennardJonesOscillator,
+    :LinearWave,
+    :LorenzAttractor,
+    :LotkaVolterra2d,
+    :LotkaVolterra3d,
+    :LotkaVolterra4d,
+    :LotkaVolterra4dLagrangian,
+    :MasslessChargedParticle,
+    :MathewsLakshmananOscillator,
+    :MorseOscillator,
+    :PointVortices,
+    :PointVorticesLinear,
+    :RigidBody,
+    :ThreeBody,
+    :TodaLattice,
+)
+
+@testset "Default timespan/timestep constants ($name)" for name in PROBLEM_MODULES
+    @test isdefined(GeometricProblems, name)
+    M = getproperty(GeometricProblems, name)
+
+    # The default timespan lives in DEFAULT_TIMESPAN and is a valid time interval.
+    @test isdefined(M, :DEFAULT_TIMESPAN)
+    @test getproperty(M, :DEFAULT_TIMESPAN) isa Tuple
+    @test length(getproperty(M, :DEFAULT_TIMESPAN)) == 2
+
+    # If a default timestep constant exists it must be named DEFAULT_TIMESTEP and be a number.
+    if isdefined(M, :DEFAULT_TIMESTEP)
+        @test getproperty(M, :DEFAULT_TIMESTEP) isa Number
+    end
+
+    # The names `timespan`/`timestep` must NOT be shadowed by a module constant:
+    # where they resolve at all, they must be the GeometricBase functions.
+    if isdefined(M, :timespan)
+        @test getproperty(M, :timespan) === timespan
+    end
+    if isdefined(M, :timestep)
+        @test getproperty(M, :timestep) === timestep
+    end
+end

--- a/test/eulerlagrange_ensembles_tests.jl
+++ b/test/eulerlagrange_ensembles_tests.jl
@@ -1,0 +1,58 @@
+using GeometricIntegrators: ImplicitMidpoint, integrate
+using Test
+
+# Tests for issue #64: parameter-varying (and initial-condition-varying) ensembles for the
+# EulerLagrange-generated HODE/LODE problems. These complement the existing ensemble tests
+# for CoupledHarmonicOscillator and TodaLattice, extending coverage to the remaining
+# EulerLagrange-based problems.
+
+import GeometricProblems.DuffingOscillator as duffing
+import GeometricProblems.MorseOscillator as morse
+import GeometricProblems.LennardJonesOscillator as lj
+import GeometricProblems.MathewsLakshmananOscillator as ml
+import GeometricProblems.DoublePendulum as dp
+import GeometricProblems.ThreeBody as tb
+import GeometricProblems.LinearWave as lw
+
+# Perturb a single parameter of the module's default parameter set.
+_perturbed(M, field, δ) = merge(M.default_parameters,
+    NamedTuple{(field,)}((getfield(M.default_parameters, field) + δ,)))
+
+# Run both an initial-condition ensemble and a parameter ensemble through a HODE and a LODE
+# integration, and assert that distinct samples yield distinct trajectories. The default
+# initial conditions are passed explicitly because the modules name them differently
+# (e.g. `q₀`, `θ₀`, `initial_condition.q`).
+function test_ensembles(M, field, δ, q₀, p₀)
+    param_vec = [M.default_parameters, _perturbed(M, field, δ)]
+
+    # Varying parameters only.
+    hsol = integrate(M.hodeensemble(; parameters = param_vec), ImplicitMidpoint())
+    lsol = integrate(M.lodeensemble(; parameters = param_vec), ImplicitMidpoint())
+    @test length(hsol.s) == 2
+    @test length(lsol.s) == 2
+    @test hsol.s[2].q.d.parent ≉ hsol.s[1].q.d.parent
+    @test lsol.s[2].q.d.parent ≉ lsol.s[1].q.d.parent
+
+    # Varying initial conditions only.
+    q₀_vec = [q₀, q₀ .+ 0.1]
+    p₀_vec = [p₀, p₀ .+ 0.1]
+    hsol_ic = integrate(M.hodeensemble(q₀_vec, p₀_vec), ImplicitMidpoint())
+    @test length(hsol_ic.s) == 2
+    @test hsol_ic.s[2].q.d.parent ≉ hsol_ic.s[1].q.d.parent
+end
+
+@testset "Duffing oscillator ensembles"            begin test_ensembles(duffing, :β, 0.5, duffing.q₀, duffing.p₀) end
+@testset "Morse oscillator ensembles"              begin test_ensembles(morse,   :D, 0.3, morse.q₀,   morse.p₀)   end
+@testset "Lennard-Jones oscillator ensembles"      begin test_ensembles(lj,      :ε, 0.2, lj.q₀,      lj.p₀)      end
+@testset "Mathews-Lakshmanan oscillator ensembles" begin test_ensembles(ml,      :λ, 0.5, ml.q₀,      ml.p₀)      end
+@testset "Double pendulum ensembles"               begin test_ensembles(dp,      :g, 0.5, dp.θ₀,      dp.p₀)      end
+@testset "Three-body ensembles"                    begin test_ensembles(tb,      :G, 0.2, tb.initial_condition.q, tb.initial_condition.p) end
+
+# The linear wave is a high-dimensional system; integrating an ensemble is expensive, so
+# here we only assert that the parameter- and IC-varying ensembles can be constructed.
+@testset "Linear wave ensembles (construction)" begin
+    param_vec = [lw.default_parameters, merge(lw.default_parameters, (μ = lw.default_parameters.μ + 0.1,))]
+    @test lw.hodeensemble(; parameters = param_vec) !== nothing
+    @test lw.lodeensemble(; parameters = param_vec) !== nothing
+    @test lw.hodeensemble([lw.q₀, lw.q₀ .+ 0.01], [lw.p₀, lw.p₀]) !== nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using SafeTestsets
 
+@safetestset "Default timespan/timestep constants (#83, #82)                                  " begin
+    include("default_timespan_timestep_tests.jl")
+end
 @safetestset "Bump initial condition: test derivative.                                        " begin
     include("bump_initial_condition_test_derivatives.jl")
 end
@@ -68,4 +71,7 @@ end
 end
 @safetestset "Toda Lattice                                                                    " begin
     include("toda_lattice_tests.jl")
+end
+@safetestset "EulerLagrange ensembles (#64)                                                   " begin
+    include("eulerlagrange_ensembles_tests.jl")
 end


### PR DESCRIPTION
## Summary

Addresses the open issues that remained after triage. Three issues (#75, #61, #47) were already resolved and have been closed separately; #76 is deferred (proposed fix recorded on the issue). This PR fixes the remaining three.

### #83 — `timespan`/`timestep` constant shadowing
PR #81 mistakenly renamed the module-level default constants `tspan`/`tstep` to `timespan`/`timestep`, which shadowed the imported `GeometricBase.timespan` / `GeometricBase.timestep` functions inside the problem modules. This renames those constants to **`DEFAULT_TIMESPAN`** / **`DEFAULT_TIMESTEP`** across all affected modules. Function keyword-argument names stay `timespan`/`timestep`; only the default-value constants are renamed. `harmonic_oscillator.jl` and `pendulum.jl` are untouched (they already avoid the clash by defining methods).

### #82 — test coverage for the rename
Adds `test/default_timespan_timestep_tests.jl` (113 assertions) verifying that in every problem module `timespan`/`timestep` resolve to the GeometricBase functions (never a shadowing constant) and that the defaults live in `DEFAULT_TIMESPAN`/`DEFAULT_TIMESTEP`.

### #64 — parameter-varying ensembles for EulerLagrange problems
Extends parameter-varying (and initial-condition-varying) `hodeensemble`/`lodeensemble` to the remaining EulerLagrange-generated problems — Duffing, Morse, Lennard-Jones, Mathews-Lakshmanan, three-body, double pendulum and linear wave — reusing the `_parameters` dispatch pattern already used by `CoupledHarmonicOscillator` and `TodaLattice`. Adds `test/eulerlagrange_ensembles_tests.jl` covering them.

## Testing
Full suite passes locally (`Pkg.test()`, exit 0): the new `#83/#82` test = 113 pass, the new `#64` test = 39 pass, no failures/errors.

Closes #83, closes #82, closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)