### PR TITLE
Add Henon–Heiles and Outer Solar System

### DIFF
--- a/src/GeometricProblems.jl
+++ b/src/GeometricProblems.jl
@@ -32,4 +32,5 @@ module GeometricProblems
     include("rigid_body.jl")
     include("three_body_problem.jl")
     include("toda_lattice.jl")
+    include("henon_heiles_potential.jl")
 end

--- a/src/GeometricProblems.jl
+++ b/src/GeometricProblems.jl
@@ -33,4 +33,5 @@ module GeometricProblems
     include("three_body_problem.jl")
     include("toda_lattice.jl")
     include("henon_heiles_potential.jl")
+    include("outer_solar_system.jl")
 end

--- a/src/henon_heiles_potential.jl
+++ b/src/henon_heiles_potential.jl
@@ -1,0 +1,61 @@
+module HenonHeilesPotential
+
+    using EulerLagrange
+    using LinearAlgebra
+    using Parameters
+
+    export hamiltonian, lagrangian
+    export hodeproblem, lodeproblem
+
+    default_parameters(::Type{T}=Float64) where {T} = (
+        λ = T(1.0),
+    )
+    
+    const p₀ = [0.3, 0.3]
+    const q₀ = [0.2, 0.2]
+    const x₀ = vcat(q₀, p₀)
+
+    const DEFAULT_TIMESTEP = 0.1
+    const DEFAULT_TIMESPAN = (0.0, 10.0)
+
+    function hamiltonian(t,q,p,params)
+        @unpack λ, = params
+        0.5 * (p[1]^2 + p[2]^2) + 0.5 * (q[1]^2 + q[2]^2) + λ * (q[1]^2 * q[2] - q[2]^3 / 3) 
+    end
+
+    function lagrangian(t,q,v,params)
+        @unpack λ, = params
+        0.5 * (v[1]^2 + v[2]^2) - 0.5 * (q[1]^2 + q[2]^2) - λ * (q[1]^2 * q[2] - q[2]^3 / 3) 
+    end        
+
+    θ̇₁(t, q, p, params) = p[1]
+    θ̇₂(t, q, p, params) = p[2]
+
+    function θ̇(v, t, q, p, params)
+        v[1] = θ̇₁(t, q, p, params)
+        v[2] = θ̇₂(t, q, p, params)
+        nothing
+    end
+
+    function hamiltonian_system(parameters::NamedTuple)
+        t, q, p = hamiltonian_variables(2)
+        sparams = symbolize(parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(2)
+        sparams = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+
+    function hodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀; parameters = parameters)
+    end
+
+    function lodeproblem(q₀ = q₀, p₀ = p₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀; v̄ = θ̇, parameters = parameters)
+    end
+
+end

--- a/src/outer_solar_system.jl
+++ b/src/outer_solar_system.jl
@@ -1,0 +1,194 @@
+@doc raw"""
+    OuterSolarSystem
+
+Gravitational N-body model of the Sun and the five outer planets (Jupiter, Saturn,
+Uranus, Neptune) and Pluto. The system has ``N = 6`` bodies in ``d = 3`` spatial
+dimensions, giving 18 degrees of freedom.
+
+The Hamiltonian is
+```math
+H(q, p) = \frac{1}{2} \sum_{i=1}^{N} \frac{p_i \cdot p_i}{m_i}
+         - G \sum_{1 \le j < i \le N} \frac{m_i \, m_j}{\| q_i - q_j \|}
+```
+where ``q_i, p_i \in \mathbb{R}^3`` are the position and momentum of body ``i``,
+and ``G`` is the gravitational constant.
+
+System parameters:
+* `G`: gravitational constant in units A.U.³ / (M_☉ · day²)
+* `m`: vector of body masses ``[m_1, \ldots, m_6]`` relative to the solar mass
+
+Initial conditions (positions in A.U., velocities in A.U./day) and constants are
+taken from E. Hairer, C. Lubich, G. Wanner, *Geometric Numerical Integration*, Chapter I.2.4.
+"""
+module OuterSolarSystem
+
+    using EulerLagrange
+    using LinearAlgebra
+    using Parameters
+
+    export hamiltonian, lagrangian
+    export hodeproblem, lodeproblem
+    export hamiltonian_system, lagrangian_system
+    export default_parameters
+
+    const N_BODIES = 6
+    const N_DIM    = 3
+
+    const DEFAULT_TIMESTEP = 0.5
+    const DEFAULT_TIMESPAN = (0.0, 200.0)
+
+    # Sun
+    const m₁ = 1.0
+    const q₁ = [0.0,        0.0,        0.0       ]
+    const q̇₁ = [0.0,        0.0,        0.0       ]
+
+    # Jupiter
+    const m₂ = 0.000954786104043
+    const q₂ = [-3.5023653,  -3.8169847,  -1.5507963]
+    const q̇₂ = [ 0.00565429,  -0.0041249,  -0.00190589]
+
+    # Saturn
+    const m₃ = 0.000285583733151
+    const q₃ = [ 9.0755314,  -3.0458353,  -1.6483708]
+    const q̇₃ = [ 0.00168318,  0.00483525,  0.00192462]
+
+    # Uranus
+    const m₄ = 0.0000437273164546
+    const q₄ = [ 8.3101420, -16.2901086,  -7.2521278]
+    const q̇₄ = [ 0.00354178,  0.00137102,  0.00055029]
+
+    # Neptune
+    const m₅ = 0.0000517759138449
+    const q₅ = [11.4707666, -25.7294829, -10.8169456]
+    const q̇₅ = [ 0.00288930,  0.00114527,  0.00039677]
+
+    # Pluto
+    const m₆ = 1.0 / 1.3e8
+    const q₆ = [-15.5387357, -25.2225594,  -3.1902382]
+    const q̇₆ = [  0.00276725,  -0.00170702,  -0.00136504]
+
+    const q₀ = [q₁; q₂; q₃; q₄; q₅; q₆]
+    const p₀ = [m₁ * q̇₁; m₂ * q̇₂; m₃ * q̇₃; m₄ * q̇₄; m₅ * q̇₅; m₆ * q̇₆]
+
+    @doc raw"Default gravitational constant G in A.U.³ / (M_☉ · day²)."
+    const G = 2.95912208286e-4
+
+    default_parameters(::Type{T} = Float64) where {T} = (
+        G = T(G),
+        m = T[m₁, m₂, m₃, m₄, m₅, m₆],
+    )
+
+    # In-place velocity estimate from momentum: q̇ᵢ = pᵢ / mᵢ (diagonal mass matrix)
+    function v̄(v, t, q, p, params)
+        @unpack m = params
+        for i in 1:N_BODIES
+            v[N_DIM*i-2] = p[N_DIM*i-2] / m[i]
+            v[N_DIM*i-1] = p[N_DIM*i-1] / m[i]
+            v[N_DIM*i  ] = p[N_DIM*i  ] / m[i]
+        end
+        nothing
+    end
+
+    function T(p::AbstractVector, params::NamedTuple)
+        @unpack m = params
+        P = reshape(p, N_DIM, N_BODIES)
+        s = zero(eltype(p))
+        for i in 1:N_BODIES
+            s += (P[1,i]^2 + P[2,i]^2 + P[3,i]^2) / m[i]
+        end
+        s / 2
+    end
+
+    function V(q::AbstractVector, params::NamedTuple)
+        @unpack G, m = params
+        Q = reshape(q, N_DIM, N_BODIES)
+        s = zero(eltype(q))
+        for i in 2:N_BODIES
+            for j in 1:i-1
+                Δ₁ = Q[1,i] - Q[1,j]
+                Δ₂ = Q[2,i] - Q[2,j]
+                Δ₃ = Q[3,i] - Q[3,j]
+                s += G * m[i] * m[j] / sqrt(Δ₁^2 + Δ₂^2 + Δ₃^2)
+            end
+        end
+        -s
+    end
+
+    function hamiltonian(t, q, p, params)
+        T(p, params) + V(q, params)
+    end
+
+    # kinetic energy in velocity form: Σ mᵢ q̇ᵢ·q̇ᵢ / 2  (not the momentum form T(p))
+    function lagrangian(t, q, q̇, params)
+        @unpack m = params
+        Q̇ = reshape(q̇, N_DIM, N_BODIES)
+        s = zero(eltype(q̇))
+        for i in 1:N_BODIES
+            s += m[i] * (Q̇[1,i]^2 + Q̇[2,i]^2 + Q̇[3,i]^2)
+        end
+        s / 2 - V(q, params)
+    end
+
+    function hamiltonian_system(parameters::NamedTuple)
+        t, q, p = hamiltonian_variables(N_BODIES * N_DIM)
+        sparams  = symbolize(parameters)
+        HamiltonianSystem(hamiltonian(t, q, p, sparams), t, q, p, sparams)
+    end
+
+    function lagrangian_system(parameters::NamedTuple)
+        t, x, v = lagrangian_variables(N_BODIES * N_DIM)
+        sparams  = symbolize(parameters)
+        LagrangianSystem(lagrangian(t, x, v, sparams), t, x, v, sparams)
+    end
+
+    """
+        hodeproblem(q₀, p₀; timespan, timestep, parameters)
+
+    Hamiltonian formulation of the outer solar system
+    (Sun, Jupiter, Saturn, Uranus, Neptune, Pluto).
+
+    Constructor with default arguments:
+    ```
+    hodeproblem(
+        q₀ = q₀,
+        p₀ = p₀;
+        timespan  = $(DEFAULT_TIMESPAN),
+        timestep  = $(DEFAULT_TIMESTEP),
+        parameters = $(default_parameters())
+    )
+    ```
+    """
+    function hodeproblem(q₀ = q₀, p₀ = p₀;
+                         timespan   = DEFAULT_TIMESPAN,
+                         timestep   = DEFAULT_TIMESTEP,
+                         parameters = default_parameters())
+        HODEProblem(hamiltonian_system(parameters), timespan, timestep, q₀, p₀;
+                    parameters = parameters)
+    end
+
+    """
+        lodeproblem(q₀, p₀; timespan, timestep, parameters)
+
+    Lagrangian formulation of the outer solar system
+    (Sun, Jupiter, Saturn, Uranus, Neptune, Pluto).
+
+    Constructor with default arguments:
+    ```
+    lodeproblem(
+        q₀ = q₀,
+        p₀ = p₀;
+        timespan   = $(DEFAULT_TIMESPAN),
+        timestep   = $(DEFAULT_TIMESTEP),
+        parameters = $(default_parameters())
+    )
+    ```
+    """
+    function lodeproblem(q₀ = q₀, p₀ = p₀;
+                         timespan   = DEFAULT_TIMESPAN,
+                         timestep   = DEFAULT_TIMESTEP,
+                         parameters = default_parameters())
+        LODEProblem(lagrangian_system(parameters), timespan, timestep, q₀, p₀;
+                    v̄ = v̄, parameters = parameters)
+    end
+
+end

--- a/test/henon_heiles_potential_tests.jl
+++ b/test/henon_heiles_potential_tests.jl
@@ -1,0 +1,21 @@
+using Test
+using GeometricIntegrators
+using GeometricProblems.HenonHeilesPotential
+using GeometricSolutions
+
+
+@testset "$(rpad("Henon Heiles Potential",80))" begin
+
+    @test_nowarn hodeproblem()
+    @test_nowarn lodeproblem()
+
+    hode = hodeproblem()
+    lode = lodeproblem()
+
+    hode_sol = integrate(hode, Gauss(2))
+    lode_sol = integrate(lode, Gauss(2))
+
+    @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1E-12
+    @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1E-11
+
+end

--- a/test/outer_solar_system_tests.jl
+++ b/test/outer_solar_system_tests.jl
@@ -1,0 +1,17 @@
+using Test
+using GeometricIntegrators
+using GeometricProblems.OuterSolarSystem
+using GeometricSolutions
+
+@testset "$(rpad("Outer Solar System",80))" begin
+
+    hode = @test_nowarn hodeproblem(timespan=(0.0,10.0))
+    lode = @test_nowarn lodeproblem(timespan=(0.0,10.0))
+
+    hode_sol = integrate(hode, ImplicitMidpoint())
+    lode_sol = integrate(lode, ImplicitMidpoint())
+
+    @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1E-12
+    @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1E-11
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,12 +72,12 @@ end
 @safetestset "Toda Lattice                                                                    " begin
     include("toda_lattice_tests.jl")
 end
+@safetestset "Henon Heiles Potential                                                          " begin
+    include("henon_heiles_potential_tests.jl")
+end
 @safetestset "EulerLagrange ensembles (#64)                                                   " begin
     include("eulerlagrange_ensembles_tests.jl")
 end
 @safetestset "Plotting extensions                                                             " begin
     include("plots_tests.jl")
-end
-@safetestset "Henon Heiles Potential                                                             " begin
-    include("henon_heiles_potential_tests.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,3 +78,6 @@ end
 @safetestset "Plotting extensions                                                             " begin
     include("plots_tests.jl")
 end
+@safetestset "Henon Heiles Potential                                                             " begin
+    include("henon_heiles_potential_tests.jl")
+end


### PR DESCRIPTION
## Summary

- Add the Henon–Heiles Potential problem. Tests passed.
- Add the Outer Solar System problem.
- Adapt both problems for precision benchmarks.
- Include only the Henon–Heiles problem in `runtests.jl`, since the Outer Solar System problem takes significantly longer to run because of the symbolic compilation in `lodeproblem`.