### PR TITLE
Add MasslessChargedParticleSingular problem

### DIFF
--- a/docs/src/massless_charged_particle.md
+++ b/docs/src/massless_charged_particle.md
@@ -26,3 +26,33 @@ nothing
 Modules = [GeometricProblems.MasslessChargedParticle]
 Order   = [:constant, :type, :macro, :function]
 ```
+
+
+## Singular vector potential
+
+```@docs
+GeometricProblems.MasslessChargedParticleSingular
+```
+
+```@eval
+using GeometricIntegrators
+using GeometricProblems.MasslessChargedParticleSingular
+using CairoMakie
+
+ode = odeproblem()
+sol = integrate(ode, Gauss(1))
+
+fig = plot_phase_portrait(sol)
+save("massless_charged_particle_singular.svg", fig)
+
+nothing
+```
+
+![](massless_charged_particle_singular.svg)
+
+
+
+```@autodocs
+Modules = [GeometricProblems.MasslessChargedParticleSingular]
+Order   = [:constant, :type, :macro, :function]
+```

--- a/ext/MasslessChargedParticlePlots.jl
+++ b/ext/MasslessChargedParticlePlots.jl
@@ -7,11 +7,16 @@ using GeometricEquations: invariants, parameters
 using GeometricSolutions: ntime, compute_invariant_error
 
 import GeometricProblems.MasslessChargedParticle
+import GeometricProblems.MasslessChargedParticleSingular
 
 # Downsampled integer time indices 0:nplot:nt (nt = :auto → all stored steps).
 _indices(sol, nplot, nt) = 0:nplot:(nt === :auto ? ntime(sol) : min(nt, ntime(sol)))
 
 _energy_error(sol, equ) = compute_invariant_error(sol.t, sol.q, parameters(equ), invariants(equ)[:h])[2]
+
+# The plot functions are gauge-agnostic: they depend only on the solution `sol`, the equation
+# `equ` (for the `:h` invariant), and the keyword arguments. The generic implementations below are
+# attached to both the standard and the singular problem's plot-function stubs.
 
 """
     plot_phase_portrait(sol; nplot, nt, latex)
@@ -27,7 +32,7 @@ Plot the `x₁`–`x₂` trajectory of a massless charged particle. Returns a Ma
 - `nt = :auto`: last time step to plot
 - `latex = true`: use LaTeX axis labels
 """
-function MasslessChargedParticle.plot_phase_portrait(sol; nplot = 1, nt = :auto, latex = true)
+function _plot_phase_portrait(sol; nplot = 1, nt = :auto, latex = true)
     idx = _indices(sol, nplot, nt)
     fig = Figure(size = (400, 400))
     ax = Axis(fig[1, 1];
@@ -45,7 +50,7 @@ end
 Plot the `x₁`–`x₂` trajectory of a massless charged particle next to its relative
 energy error. Returns a Makie `Figure`.
 """
-function MasslessChargedParticle.plot_solution(sol, equ; nplot = 1, nt = :auto, latex = true)
+function _plot_solution(sol, equ; nplot = 1, nt = :auto, latex = true)
     idx = _indices(sol, nplot, nt)
     ΔH  = _energy_error(sol, equ)
 
@@ -74,7 +79,7 @@ Plot the time traces `x₁(t)`, `x₂(t)` of a massless charged particle traject
 together with its relative energy error, stacked vertically. Returns a Makie
 `Figure`.
 """
-function MasslessChargedParticle.plot_traces(sol, equ; nplot = 1, nt = :auto, latex = true)
+function _plot_traces(sol, equ; nplot = 1, nt = :auto, latex = true)
     idx = _indices(sol, nplot, nt)
     ts  = [sol.t[k] for k in idx]
     ΔH  = _energy_error(sol, equ)
@@ -93,5 +98,14 @@ function MasslessChargedParticle.plot_traces(sol, equ; nplot = 1, nt = :auto, la
     lines!(ax_energy, ts, [ΔH[k] for k in idx])
     return fig
 end
+
+# Attach the generic implementations to both problems' plot-function stubs.
+MasslessChargedParticle.plot_phase_portrait(sol; kwargs...) = _plot_phase_portrait(sol; kwargs...)
+MasslessChargedParticle.plot_solution(sol, equ; kwargs...) = _plot_solution(sol, equ; kwargs...)
+MasslessChargedParticle.plot_traces(sol, equ; kwargs...) = _plot_traces(sol, equ; kwargs...)
+
+MasslessChargedParticleSingular.plot_phase_portrait(sol; kwargs...) = _plot_phase_portrait(sol; kwargs...)
+MasslessChargedParticleSingular.plot_solution(sol, equ; kwargs...) = _plot_solution(sol, equ; kwargs...)
+MasslessChargedParticleSingular.plot_traces(sol, equ; kwargs...) = _plot_traces(sol, equ; kwargs...)
 
 end

--- a/src/GeometricProblems.jl
+++ b/src/GeometricProblems.jl
@@ -23,6 +23,7 @@ module GeometricProblems
     include("lotka_volterra_4d.jl")
     include("lotka_volterra_4d_lagrangian.jl")
     include("massless_charged_particle.jl")
+    include("massless_charged_particle_singular.jl")
     include("coupled_harmonic_oscillator.jl")
     include("mathews_lakshmanan_oscillator.jl")
     include("morse_oscillator.jl")

--- a/src/massless_charged_particle.jl
+++ b/src/massless_charged_particle.jl
@@ -32,68 +32,19 @@ The Hamiltonian form of the equations of motion reads
 \end{pmatrix} \nabla \phi (x) .
 ```
 
+See [`GeometricProblems.MasslessChargedParticleSingular`](@ref) for a formulation with the same
+magnetic field but a "singular" (one-component) vector potential, suitable for degenerate
+variational integrators.
+
 """
 module MasslessChargedParticle
-
-    using GeometricEquations
-    using GeometricSolutions
-
-    export ϑ, A, B, ϕ, E, hamiltonian
-    export odeproblem, iodeproblem, idaeproblem, idaeproblem_spark
-    export compute_energy_error, compute_momentum_error
-
-
-    # default simulation parameters
-    const Δt = 0.2
-    const nt = 5000
-    const DEFAULT_TIMESPAN = (0.0, Δt*nt)
-    const DEFAULT_TIMESTEP = Δt
-
-    # default initial conditions and parameters
-    const q₀ = [1.0, 1.0]
-
-    default_parameters(::Type{T}=Float64) where {T} = (A₀ = T(1.0), E₀ = T(1.0))
 
     # components of the vector potential
     A₁(q, params) = - params[:A₀] * q[2] * (1 + q[1]^2 + q[2]^2) / 2
     A₂(q, params) = + params[:A₀] * q[1] * (1 + q[1]^2 + q[2]^2) / 2
 
-    A(q, params) = [A₁(q, params), A₂(q, params)]
-
     # z-componend of the magnetic field
     B(q, params) = params[:A₀] * (1 + 2 * q[1]^2 + 2 * q[2]^2)
-
-    # electrostatic potential
-    ϕ(q, params) = params[:E₀] * (cos(q[1]) + sin(q[2]))
-    # ϕ(q, params) = E₀ * (q[1]^2 + q[2]^2)
-
-    # components of the electric field
-    E₁(q, params) = + params[:E₀] * sin(q[1])
-    E₂(q, params) = - params[:E₀] * cos(q[2])
-    # E₁(q, params) = + params[:E₀] * q[1]
-    # E₂(q, params) = + params[:E₀] * q[2]
-
-    E(q, params) = [E₁(q, params), E₂(q, params)]
-
-    # components of the velocity
-    v₁(t, q, params) = + E₂(q, params) / B(q, params)
-    v₂(t, q, params) = - E₁(q, params) / B(q, params)
-
-    # components of the one-form (symplectic potential)
-    ϑ₁(t, q, params) = A₁(q, params)
-    ϑ₂(t, q, params) = A₂(q, params)
-
-    ϑ(t, q, params) = [ϑ₁(t, q, params), ϑ₂(t, q, params)]
-
-    function ϑ(t, q::AbstractVector, params::NamedTuple, k::Int)
-        if k == 1
-            ϑ₁(t, q, params)
-        elseif k == 2
-            ϑ₂(t, q, params)
-        else
-            throw(BoundsError(ϑ,k))
-        end
-    end
 
     # derivatives of the one-form components
     dϑ₁dx₁(t, q, params) = - params[:A₀] * q[1] * q[2]
@@ -101,136 +52,7 @@ module MasslessChargedParticle
     dϑ₂dx₁(t, q, params) = + params[:A₀] * (1 + 3 * q[1]^2 + q[2]^2) / 2
     dϑ₂dx₂(t, q, params) = + params[:A₀] * q[1] * q[2]
 
-    # components of the force
-    f₁(v, t, q, params) = dϑ₁dx₁(t, q, params) * v[1] + dϑ₂dx₁(t, q, params) * v[2]
-    f₂(v, t, q, params) = dϑ₁dx₂(t, q, params) * v[1] + dϑ₂dx₂(t, q, params) * v[2]
 
-    g₁(v, t, q, params) = dϑ₁dx₁(t, q, params) * v[1] + dϑ₁dx₂(t, q, params) * v[2]
-    g₂(v, t, q, params) = dϑ₂dx₁(t, q, params) * v[1] + dϑ₂dx₂(t, q, params) * v[2]
-
-    # Hamiltonian (total energy)
-    hamiltonian(t, q, params) = ϕ(q, params)
-
-    # components of the gradient of the Hamiltonian
-    dHd₁(t, q, params) = - E₁(q, params)
-    dHd₂(t, q, params) = - E₂(q, params)
-
-
-    function massless_charged_particle_dH(dH, t, q, params)
-        dH[1] = dHd₁(t, q, params)
-        dH[2] = dHd₂(t, q, params)
-        nothing
-    end
-
-    function massless_charged_particle_v(v, t, q, params)
-        v[1] = v₁(t, q, params)
-        v[2] = v₂(t, q, params)
-        nothing
-    end
-
-    function massless_charged_particle_v(v, t, q, p, params)
-        massless_charged_particle_v(v, t, q, params)
-    end
-
-    function massless_charged_particle_ϑ(Θ, t, q, params)
-        Θ[1] = ϑ₁(t, q, params)
-        Θ[2] = ϑ₂(t, q, params)
-        nothing
-    end
-
-    massless_charged_particle_ϑ(Θ, t, q, v, params) = massless_charged_particle_ϑ(Θ, t, q, params)
-
-    function massless_charged_particle_f(f, t, q, v, params)
-        f[1] = f₁(v, t, q, params) - dHd₁(t, q, params)
-        f[2] = f₂(v, t, q, params) - dHd₂(t, q, params)
-        nothing
-    end
-
-    function massless_charged_particle_f̄(f, t, q, v, params)
-        f[1] = - dHd₁(t, q, params)
-        f[2] = - dHd₂(t, q, params)
-        nothing
-    end
-
-    function massless_charged_particle_g(g, t, q, v, params)
-        g[1] = f₁(v, t, q, params)
-        g[2] = f₂(v, t, q, params)
-        nothing
-    end
-
-    massless_charged_particle_g(g, t, q, p, v, params) = massless_charged_particle_g(g, t, q, v, params)
-    # IDAE evaluates the constraint force g with the multiplier λ (mirrors LotkaVolterra2d).
-    massless_charged_particle_g(g, t, q, v, p, λ, params) = massless_charged_particle_g(g, t, q, λ, params)
-
-    function massless_charged_particle_u(u, t, q, v, params)
-        u .= v
-        nothing
-    end
-
-    massless_charged_particle_u(u, t, q, p, v, params) = massless_charged_particle_u(u, t, q, v, params)
-    # IDAE projects along the multiplier λ (u .= λ), mirroring LotkaVolterra2d.
-    massless_charged_particle_u(u, t, q, v, p, λ, params) = massless_charged_particle_u(u, t, q, λ, params)
-
-    function massless_charged_particle_ϕ(ϕ, t, q, p, params)
-        ϕ[1] = p[1] - ϑ₁(t,q,params)
-        ϕ[2] = p[2] - ϑ₂(t,q,params)
-        nothing
-    end
-    # IDAE calls ϕ with an extra velocity slot; the constraint p = ϑ(q) does not depend on it.
-    massless_charged_particle_ϕ(ϕ, t, q, v, p, params) = massless_charged_particle_ϕ(ϕ, t, q, p, params)
-
-    function massless_charged_particle_ψ(ψ, t, q, p, v, f, params)
-        ψ[1] = f[1] - g₁(v,t,q,params)
-        ψ[2] = f[2] - g₂(v,t,q,params)
-        nothing
-    end
-
-
-
-    "Creates an ODE object for the massless charged particle in 2D."
-    function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
-        ODEProblem(massless_charged_particle_v, timespan, timestep, q₀; invariants=(h=hamiltonian,), parameters=parameters)
-    end
-
-    "Creates an implicit ODE object for the massless charged particle in 2D."
-    function iodeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
-        IODEProblem(massless_charged_particle_ϑ, massless_charged_particle_f,
-                massless_charged_particle_g,
-                timespan, timestep, q₀, ϑ(0., q₀, parameters);
-                v̄=massless_charged_particle_v, f̄=massless_charged_particle_f,
-                invariants=(h=hamiltonian,), parameters=parameters)
-    end
-
-    "Creates an implicit DAE object for the massless charged particle in 2D."
-    function idaeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
-        IDAEProblem(massless_charged_particle_ϑ, massless_charged_particle_f,
-                massless_charged_particle_u, massless_charged_particle_g,
-                massless_charged_particle_ϕ,
-                timespan, timestep, q₀, ϑ(0., q₀, parameters), zero(q₀);
-                v̄=massless_charged_particle_v, f̄=massless_charged_particle_f,
-                invariants=(h=hamiltonian,), parameters=parameters)
-    end
-
-    "Creates an implicit DAE object for the massless charged particle in 2D."
-    function idaeproblem_spark(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
-        IDAEProblem(massless_charged_particle_ϑ, massless_charged_particle_f̄,
-                massless_charged_particle_u, massless_charged_particle_g,
-                massless_charged_particle_ϕ,
-                timespan, timestep, q₀, ϑ(0., q₀, parameters), zero(q₀);
-                v̄=massless_charged_particle_v, f̄=massless_charged_particle_f,
-                invariants=(h=hamiltonian,), parameters=parameters)
-    end
-
-
-    compute_energy_error(t,q,params) = compute_invariant_error(t,q, (t,q) -> hamiltonian(t,q,params))
-    compute_momentum_error(t,q,p,params::NamedTuple) = compute_momentum_error(t, q, p, (t,q,k) -> ϑ(t,q,params,k))
-
-
-    export plot_solution, plot_phase_portrait, plot_traces
-
-    # Plot functions are implemented in the `MasslessChargedParticlePlots` extension (loaded with Makie).
-    function plot_solution end
-    function plot_phase_portrait end
-    function plot_traces end
+    include("massless_charged_particle_common.jl")
 
 end

--- a/src/massless_charged_particle_common.jl
+++ b/src/massless_charged_particle_common.jl
@@ -1,0 +1,183 @@
+
+using GeometricEquations
+using GeometricSolutions
+
+export ϑ, A, B, ϕ, E, hamiltonian
+export odeproblem, iodeproblem, idaeproblem, idaeproblem_spark
+export compute_energy_error, compute_momentum_error
+
+
+# default simulation parameters
+const Δt = 0.2
+const nt = 5000
+const DEFAULT_TIMESPAN = (0.0, Δt*nt)
+const DEFAULT_TIMESTEP = Δt
+
+# default initial conditions and parameters
+const q₀ = [1.0, 1.0]
+
+default_parameters(::Type{T}=Float64) where {T} = (A₀ = T(1.0), E₀ = T(1.0))
+
+# vector potential (components A₁, A₂ are defined by the including module)
+A(q, params) = [A₁(q, params), A₂(q, params)]
+
+# electrostatic potential
+ϕ(q, params) = params[:E₀] * (cos(q[1]) + sin(q[2]))
+
+# components of the electric field
+E₁(q, params) = + params[:E₀] * sin(q[1])
+E₂(q, params) = - params[:E₀] * cos(q[2])
+
+E(q, params) = [E₁(q, params), E₂(q, params)]
+
+# components of the velocity (B is defined by the including module)
+v₁(t, q, params) = + E₂(q, params) / B(q, params)
+v₂(t, q, params) = - E₁(q, params) / B(q, params)
+
+# components of the one-form (symplectic potential)
+ϑ₁(t, q, params) = A₁(q, params)
+ϑ₂(t, q, params) = A₂(q, params)
+
+ϑ(t, q, params) = [ϑ₁(t, q, params), ϑ₂(t, q, params)]
+
+function ϑ(t, q::AbstractVector, params::NamedTuple, k::Int)
+    if k == 1
+        ϑ₁(t, q, params)
+    elseif k == 2
+        ϑ₂(t, q, params)
+    else
+        throw(BoundsError(ϑ,k))
+    end
+end
+
+# components of the force (derivatives dϑᵢdxⱼ are defined by the including module)
+f₁(v, t, q, params) = dϑ₁dx₁(t, q, params) * v[1] + dϑ₂dx₁(t, q, params) * v[2]
+f₂(v, t, q, params) = dϑ₁dx₂(t, q, params) * v[1] + dϑ₂dx₂(t, q, params) * v[2]
+
+g₁(v, t, q, params) = dϑ₁dx₁(t, q, params) * v[1] + dϑ₁dx₂(t, q, params) * v[2]
+g₂(v, t, q, params) = dϑ₂dx₁(t, q, params) * v[1] + dϑ₂dx₂(t, q, params) * v[2]
+
+# Hamiltonian (total energy)
+hamiltonian(t, q, params) = ϕ(q, params)
+
+# components of the gradient of the Hamiltonian
+dHd₁(t, q, params) = - E₁(q, params)
+dHd₂(t, q, params) = - E₂(q, params)
+
+
+function massless_charged_particle_dH(dH, t, q, params)
+    dH[1] = dHd₁(t, q, params)
+    dH[2] = dHd₂(t, q, params)
+    nothing
+end
+
+function massless_charged_particle_v(v, t, q, params)
+    v[1] = v₁(t, q, params)
+    v[2] = v₂(t, q, params)
+    nothing
+end
+
+function massless_charged_particle_v(v, t, q, p, params)
+    massless_charged_particle_v(v, t, q, params)
+end
+
+function massless_charged_particle_ϑ(Θ, t, q, params)
+    Θ[1] = ϑ₁(t, q, params)
+    Θ[2] = ϑ₂(t, q, params)
+    nothing
+end
+
+massless_charged_particle_ϑ(Θ, t, q, v, params) = massless_charged_particle_ϑ(Θ, t, q, params)
+
+function massless_charged_particle_f(f, t, q, v, params)
+    f[1] = f₁(v, t, q, params) - dHd₁(t, q, params)
+    f[2] = f₂(v, t, q, params) - dHd₂(t, q, params)
+    nothing
+end
+
+function massless_charged_particle_f̄(f, t, q, v, params)
+    f[1] = - dHd₁(t, q, params)
+    f[2] = - dHd₂(t, q, params)
+    nothing
+end
+
+function massless_charged_particle_g(g, t, q, v, params)
+    g[1] = f₁(v, t, q, params)
+    g[2] = f₂(v, t, q, params)
+    nothing
+end
+
+massless_charged_particle_g(g, t, q, p, v, params) = massless_charged_particle_g(g, t, q, v, params)
+# IDAE evaluates the constraint force g with the multiplier λ (mirrors LotkaVolterra2d).
+massless_charged_particle_g(g, t, q, v, p, λ, params) = massless_charged_particle_g(g, t, q, λ, params)
+
+function massless_charged_particle_u(u, t, q, v, params)
+    u .= v
+    nothing
+end
+
+massless_charged_particle_u(u, t, q, p, v, params) = massless_charged_particle_u(u, t, q, v, params)
+# IDAE projects along the multiplier λ (u .= λ), mirroring LotkaVolterra2d.
+massless_charged_particle_u(u, t, q, v, p, λ, params) = massless_charged_particle_u(u, t, q, λ, params)
+
+function massless_charged_particle_ϕ(ϕ, t, q, p, params)
+    ϕ[1] = p[1] - ϑ₁(t,q,params)
+    ϕ[2] = p[2] - ϑ₂(t,q,params)
+    nothing
+end
+# IDAE calls ϕ with an extra velocity slot; the constraint p = ϑ(q) does not depend on it.
+massless_charged_particle_ϕ(ϕ, t, q, v, p, params) = massless_charged_particle_ϕ(ϕ, t, q, p, params)
+
+function massless_charged_particle_ψ(ψ, t, q, p, v, f, params)
+    ψ[1] = f[1] - g₁(v,t,q,params)
+    ψ[2] = f[2] - g₂(v,t,q,params)
+    nothing
+end
+
+
+
+"Creates an ODE object for the massless charged particle in 2D."
+function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
+    ODEProblem(massless_charged_particle_v, timespan, timestep, q₀; invariants=(h=hamiltonian,), parameters=parameters)
+end
+
+"Creates an implicit ODE object for the massless charged particle in 2D."
+function iodeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
+    IODEProblem(massless_charged_particle_ϑ, massless_charged_particle_f,
+            massless_charged_particle_g,
+            timespan, timestep, q₀, ϑ(0., q₀, parameters);
+            v̄=massless_charged_particle_v, f̄=massless_charged_particle_f,
+            invariants=(h=hamiltonian,), parameters=parameters)
+end
+
+"Creates an implicit DAE object for the massless charged particle in 2D."
+function idaeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
+    IDAEProblem(massless_charged_particle_ϑ, massless_charged_particle_f,
+            massless_charged_particle_u, massless_charged_particle_g,
+            massless_charged_particle_ϕ,
+            timespan, timestep, q₀, ϑ(0., q₀, parameters), zero(q₀);
+            v̄=massless_charged_particle_v, f̄=massless_charged_particle_f,
+            invariants=(h=hamiltonian,), parameters=parameters)
+end
+
+"Creates an implicit DAE object for the massless charged particle in 2D."
+function idaeproblem_spark(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters = default_parameters())
+    IDAEProblem(massless_charged_particle_ϑ, massless_charged_particle_f̄,
+            massless_charged_particle_u, massless_charged_particle_g,
+            massless_charged_particle_ϕ,
+            timespan, timestep, q₀, ϑ(0., q₀, parameters), zero(q₀);
+            v̄=massless_charged_particle_v, f̄=massless_charged_particle_f,
+            invariants=(h=hamiltonian,), parameters=parameters)
+end
+
+
+compute_energy_error(t,q,params) = compute_invariant_error(t,q, (t,q) -> hamiltonian(t,q,params))
+compute_momentum_error(t,q,p,params::NamedTuple) = compute_momentum_error(t, q, p, (t,q,k) -> ϑ(t,q,params,k))
+
+
+export plot_solution, plot_phase_portrait, plot_traces
+
+# Plot functions are implemented in the `MasslessChargedParticlePlots` extension (loaded with Makie).
+function plot_solution end
+function plot_phase_portrait end
+function plot_traces end

--- a/src/massless_charged_particle_singular.jl
+++ b/src/massless_charged_particle_singular.jl
@@ -1,0 +1,61 @@
+@doc raw"""
+# Massless charged particle in 2D with "singular" vector potential
+
+The Lagrangian is given by
+```math
+L(x, \dot{x}) = A(x) \cdot \dot{x} - \phi (x) ,
+```
+with the "singular" (one-component) magnetic vector potential
+```math
+A(x) = - A_0 \, x_2 \, \big( 1 + 2 x_1^2 + \tfrac{2}{3} x_2^2 \big) \begin{pmatrix}
+1 \\
+0 \\
+\end{pmatrix} ,
+```
+electrostatic potential
+```math
+\phi(x) =  E_0 \, \big( \cos (x_1) + \sin(x_2) \big) ,
+```
+and magnetic and electric fields
+```math
+\begin{aligned}
+B(x) &= \nabla \times A(x) = A_0 \, (1 + 2 x_1^2 + 2 x_2^2) , \\
+E(x) &= - \nabla \phi(x) = E_0 \, \big( \sin x_1, \, - \cos x_2 \big)^T .
+\end{aligned}
+```
+
+The Hamiltonian form of the equations of motion reads
+```math
+\dot{x} = \frac{1}{B(x)} \begin{pmatrix}
+\hphantom{-} 0 & - 1 \\
++ 1 & \hphantom{+} 0 \\
+\end{pmatrix} \nabla \phi (x) .
+```
+
+This is the same physical system as [`GeometricProblems.MasslessChargedParticle`](@ref): the
+magnetic field ``B``, electric field ``E`` and hence the dynamics are identical. Only the vector
+potential differs by a gauge transformation, chosen here so that its second component vanishes
+(``A_2 = 0``). This "singular" one-form yields the same Euler-Lagrange equations but a different
+variational integrator, and is the form required by the degenerate variational integrator (DVI)
+method of GeometricIntegrators.
+
+"""
+module MasslessChargedParticleSingular
+
+    # components of the vector potential (singular gauge, A₂ = 0)
+    A₁(q, params) = - params[:A₀] * q[2] * (1 + 2 * q[1]^2 + 2 * q[2]^2 / 3)
+    A₂(q, params) = zero(eltype(q))
+
+    # z-componend of the magnetic field (same as the standard vector potential)
+    B(q, params) = params[:A₀] * (1 + 2 * q[1]^2 + 2 * q[2]^2)
+
+    # derivatives of the one-form components
+    dϑ₁dx₁(t, q, params) = - 4 * params[:A₀] * q[1] * q[2]
+    dϑ₁dx₂(t, q, params) = - params[:A₀] * (1 + 2 * q[1]^2 + 2 * q[2]^2)
+    dϑ₂dx₁(t, q, params) = zero(eltype(q))
+    dϑ₂dx₂(t, q, params) = zero(eltype(q))
+
+
+    include("massless_charged_particle_common.jl")
+
+end

--- a/test/massless_charged_particle_singular_tests.jl
+++ b/test/massless_charged_particle_singular_tests.jl
@@ -1,0 +1,54 @@
+using Test
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricSolutions
+
+import GeometricProblems.MasslessChargedParticle as mcp
+import GeometricProblems.MasslessChargedParticleSingular as mcps
+
+# The singular problem uses a gauge-transformed, one-component vector potential (A₂ = 0). It
+# describes the same physics as the standard massless charged particle: same magnetic field B,
+# same electric field, hence the same velocity field. Only the one-form ϑ = A differs, which
+# yields a different (degenerate) variational integrator. As for the standard problem, the ODE
+# vector field must satisfy the Euler–Lagrange relation Ω v = -∇H, where
+# Ω_ij = ∂ϑ_i/∂q_j - ∂ϑ_j/∂q_i is the (anti-symmetric) symplectic matrix.
+
+@testset "$(rpad("Massless Charged Particle (singular)",80))" begin
+    params = mcps.default_parameters()
+
+    for q in ([1.0, 1.0], [0.5, -0.7], [1.3, 0.2], [-0.9, 0.4])
+        v = zeros(2)
+        mcps.massless_charged_particle_v(v, 0.0, q, params)
+
+        Ω₁₂ = mcps.dϑ₁dx₂(0.0, q, params) - mcps.dϑ₂dx₁(0.0, q, params)
+        ∇H  = [mcps.dHd₁(0.0, q, params), mcps.dHd₂(0.0, q, params)]
+        Ωv  = [Ω₁₂ * v[2], -Ω₁₂ * v[1]]   # (anti-symmetric) Ω acting on v
+
+        # Euler–Lagrange / IODE consistency of the ODE vector field: Ω v = -∇H
+        @test Ωv ≈ -∇H atol = 1e-12
+
+        # the drift is orthogonal to ∇H, i.e. the Hamiltonian (energy) is conserved
+        @test abs(sum(v .* ∇H)) < 1e-12
+
+        # the singular gauge reproduces the same magnetic field and hence the same dynamics
+        @test mcps.B(q, params) ≈ mcp.B(q, params) atol = 1e-12
+
+        v_std = zeros(2)
+        mcp.massless_charged_particle_v(v_std, 0.0, q, params)
+        @test v ≈ v_std atol = 1e-12
+    end
+end
+
+# The variational (IDAE) formulations must reproduce the ODE dynamics. `idaeproblem` is a
+# variational integrator problem (VSPARK), `idaeproblem_spark` uses the force-split SPARK form.
+@testset "$(rpad("Massless Charged Particle (singular, variational)",80))" begin
+    tspan = (0.0, 1.0)
+    tstep = 0.05
+    ref = integrate(mcps.odeproblem(; timespan = tspan, timestep = tstep), Gauss(8))
+
+    sol = integrate(mcps.idaeproblem(; timespan = tspan, timestep = tstep), TableauVSPARKGLRKpMidpoint(2))
+    @test relative_maximum_error(sol.q, ref.q) < 1E-8
+
+    sol = integrate(mcps.idaeproblem_spark(; timespan = tspan, timestep = tstep), SPARKGLRK(2))
+    @test relative_maximum_error(sol.q, ref.q) < 1E-8
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ end
 @safetestset "Massless Charged Particle                                                       " begin
     include("massless_charged_particle_tests.jl")
 end
+@safetestset "Massless Charged Particle (singular)                                            " begin
+    include("massless_charged_particle_singular_tests.jl")
+end
 @safetestset "Three-Body Problem                                                              " begin
     include("three_body_tests.jl")
 end


### PR DESCRIPTION
## Summary

Adds a second massless charged particle problem, `MasslessChargedParticleSingular`, that uses a **singular** (one-component) magnetic vector potential with `A₂ = 0`:

```
A₁ = −A₀·q₂·(1 + 2q₁² + ⅔q₂²)
A₂ = 0
```

This is a gauge transformation of the standard problem chosen so that the second component vanishes while reproducing the **same** magnetic field `B = A₀·(1 + 2q₁² + 2q₂²)`, electric field, and dynamics. The singular one-form yields the same Euler–Lagrange equations but a different variational integrator, and is the form required by the degenerate variational integrator (DVI) method of GeometricIntegrators.

## Changes

- **`src/massless_charged_particle_common.jl`** (new) — shared functionality (constants, `default_parameters`, `A`/`ϑ`/`ϕ`/`E`/`v`, forces, Hamiltonian, `massless_charged_particle_*` callbacks, the four problem constructors, error diagnostics, plot stubs), built on the gauge-specific primitives supplied by the including module.
- **`src/massless_charged_particle_singular.jl`** (new) — `MasslessChargedParticleSingular` module: singular-gauge primitives + `include` of the common file.
- **`src/massless_charged_particle.jl`** — reduced to its docstring + standard-gauge primitives + `include` of the common file (behavior unchanged). This mirrors the existing `LotkaVolterra2dSingular` pattern.
- **`src/GeometricProblems.jl`** — register the new problem.
- **`ext/MasslessChargedParticlePlots.jl`** — refactor plot bodies into generic helpers attached to both modules' stubs (no `Project.toml` change).
- **`test/massless_charged_particle_singular_tests.jl`** (new) + **`test/runtests.jl`** — mirror the standard tests (Ω·v = −∇H consistency, energy conservation, VSPARK/SPARK variational reproduction) plus cross-checks that `B` and `v` match the standard problem.
- **`docs/src/massless_charged_particle.md`** — new "Singular vector potential" section with docstring, phase-portrait figure, and autodocs.

## Testing

Full test suite passes (via the pre-push hook), including the new `Massless Charged Particle (singular)` and `Massless Charged Particle (singular, variational)` testsets and the plotting extension tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)