### PR TITLE
Generic invariant and convergence diagnostics; point-vortex plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,25 @@ Categories: **Bug fixes** = code defects (typos, wrong API calls, crashes, bad i
   symmetric variant. `src/lotka_volterra_2d_gauge.jl`.
 
 ### New features
+- **Generic invariant diagnostics**: `Diagnostics.plot_invariant_error` and
+  `Diagnostics.plot_invariant_drift` plot the relative error (and its per-interval drift) of *any*
+  invariant a problem carries, selected by its key in `invariants(problem)` (`:h` by default) or
+  by passing the invariant function itself. `plot_energy_error`/`plot_energy_drift` are now the
+  `:h` special case of these and keep their previous behaviour and axis labels.
+  Motivated by problems with more than one conserved quantity — the point vortices below, and the
+  guiding-centre toroidal momentum in `ChargedParticleDynamics` — which previously each needed
+  their own bespoke plotting code. `src/diagnostics.jl`, `ext/DiagnosticsPlots.jl`.
+- **Convergence diagnostics**: `Diagnostics.plot_convergence(h, ε; order)` (log-log error over
+  time step, with an optional reference slope of the expected order) and
+  `Diagnostics.plot_order(h, p)` (observed order over time step). `src/diagnostics.jl`,
+  `ext/DiagnosticsPlots.jl`.
+- **Point vortices**: added a `PointVorticesPlots` Makie extension providing
+  `plot_phase_portrait`, `plot_solution` and `plot_traces` for both `PointVortices` and
+  `PointVorticesLinear`, mirroring `MasslessChargedParticlePlots`. Both modules' problems now also
+  declare their invariants, `invariants=(h=hamiltonian, p=angular_momentum)`, which they were
+  missing entirely, so that the generic diagnostics above work on them; `angular_momentum` gained
+  the four-argument `(t, q, p, params)` method the implicit formulations evaluate it with.
+  `ext/PointVorticesPlots.jl`, `src/point_vortices.jl`, `src/point_vortices_linear.jl`.
 - **Massless charged particle**: added `lodeproblem` and `ldaeproblem` to both
   `MasslessChargedParticle` and `MasslessChargedParticleSingular`, completing the variational
   formulations. This required the two previously missing ingredients, both derived from what the

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricProblems"
 uuid = "18cb22b4-ad41-5c80-9c5f-710df63fbdc9"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de>"]
 
 [deps]
@@ -39,6 +39,7 @@ LotkaVolterra3dPlots = "Makie"
 LotkaVolterra4dPlots = "Makie"
 MasslessChargedParticlePlots = "Makie"
 PendulumPlots = "Makie"
+PointVorticesPlots = "Makie"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -16,9 +16,21 @@ and its relative error.
 ## Diagnostic plots
 
 When a Makie backend such as `CairoMakie` is loaded, the `Diagnostics` module provides generic
-plotting functions — `plot_energy_error`, `plot_energy_drift`, `plot_constraint_error`, and
-`plot_lagrange_multiplier` — that visualise these diagnostics for a `GeometricSolution`. For an ODE
-solution with an energy invariant, `plot_energy_error` shows the relative energy drift over time:
+plotting functions that visualise these diagnostics for a `GeometricSolution`:
+
+* `plot_energy_error` and `plot_energy_drift` — the relative error of the energy, and its
+  maximum absolute value per time interval;
+* `plot_invariant_error` and `plot_invariant_drift` — the same for *any* invariant the problem
+  carries, selected with the `invariant` keyword (a key into `invariants(problem)`, `:h` by
+  default, or the invariant function itself). The energy variants above are the `:h` special
+  case;
+* `plot_constraint_error` and `plot_lagrange_multiplier` — the drift of the momentum one-form
+  and the multipliers of an implicit/variational (DAE) solution;
+* `plot_convergence` and `plot_order` — the error and the observed order of convergence over a
+  sequence of time steps, for a convergence study.
+
+For an ODE solution with an energy invariant, `plot_energy_error` shows the relative energy
+drift over time:
 
 ```@example diagnostics
 using GeometricProblems.LotkaVolterra2d
@@ -37,4 +49,15 @@ one-form, with one stacked panel per degree of freedom:
 ```@example diagnostics
 dsol = integrate(idaeproblem(), TableauVSPARKGLRKpMidpoint(2))
 plot_constraint_error(dsol)
+```
+
+Problems with more than one conserved quantity are what `plot_invariant_error` is for. The
+[point vortices](point_vortices.md), for instance, conserve both the energy `:h` and the
+angular momentum `:p`:
+
+```@example diagnostics
+import GeometricProblems.PointVortices as pv
+
+pvsol = integrate(pv.odeproblem(), Gauss(1))
+plot_invariant_error(pvsol; invariant = :p)
 ```

--- a/docs/src/point_vortices.md
+++ b/docs/src/point_vortices.md
@@ -9,13 +9,11 @@ using CairoMakie
 
 sol = integrate(odeproblem(), ImplicitMidpoint())
 
-fig = Figure()
-ax = Axis(fig[1, 1]; xlabel = "x", ylabel = "y", aspect = DataAspect(), title = "Point vortices")
-lines!(ax, sol.q[:, 1], sol.q[:, 2]; label = "vortex 1")
-lines!(ax, sol.q[:, 3], sol.q[:, 4]; label = "vortex 2")
-axislegend(ax)
-fig
+plot_phase_portrait(sol)
 ```
+
+Both point-vortex modules conserve the energy `:h` and the angular momentum `:p`, so the
+generic [diagnostic plots](diagnostics.md) work on their solutions for either invariant.
 
 ```@autodocs
 Modules = [GeometricProblems.PointVortices]

--- a/ext/DiagnosticsPlots.jl
+++ b/ext/DiagnosticsPlots.jl
@@ -18,16 +18,35 @@ function _steprange(t, nplot, nt)
     return 0:nplot:n
 end
 
-# Compute the relative energy error of a solution from its `:h` invariant.
-function _energy_error(sol; energy = nothing)
-    h = energy === nothing ? invariants(sol.problem)[:h] : energy
+# Compute the relative error of one of a solution's invariants. `invariant` is either a key
+# into `invariants(sol.problem)` or the invariant function itself.
+function _invariant_error(sol, invariant)
+    f = invariant isa Symbol ? invariants(sol.problem)[invariant] : invariant
     params = parameters(sol.problem)
     if sol isa Union{SolutionPODE, SolutionPDAE}
-        _, ΔH = compute_invariant_error(sol.t, sol.q, sol.p, params, h)
+        _, Δ = compute_invariant_error(sol.t, sol.q, sol.p, params, f)
     else
-        _, ΔH = compute_invariant_error(sol.t, sol.q, params, h)
+        _, Δ = compute_invariant_error(sol.t, sol.q, params, f)
     end
-    return ΔH
+    return Δ
+end
+
+# Compute the relative energy error of a solution from its `:h` invariant.
+_energy_error(sol; energy = nothing) = _invariant_error(sol, energy === nothing ? :h : energy)
+
+# Default axis labels for the error and the drift of an invariant named `s`, e.g. `:h` → "H".
+# A non-`Symbol` invariant (a bare function) has no name to show, so it falls back to "I".
+_invariant_name(s::Symbol) = uppercase(string(s))
+_invariant_name(_) = "I"
+
+function _error_label(s, latex)
+    n = _invariant_name(s)
+    latex ? L"[%$n(t) - %$n(0)] / %$n(0)" : "[$n(t) - $n(0)] / $n(0)"
+end
+
+function _drift_label(s, latex)
+    n = _invariant_name(s)
+    latex ? L"\Delta %$n" : "Δ$n"
 end
 
 # Stack one axis per component of a per-DOF time series (constraint error, λ, …).
@@ -55,6 +74,65 @@ function _plot_components(t, d, label; nplot = 1, nt = :auto, k = 0, latex = tru
 end
 
 """
+    plot_invariant_error(t, Δ; ylabel, nplot, nt, latex)
+    plot_invariant_error(sol::GeometricSolution; invariant, ylabel, nplot, nt, latex)
+
+Plot the relative error `[I(t) - I(0)] / I(0)` of an invariant as a function of time.
+
+Either pass a precomputed error series (`t::TimeSeries`, `Δ::DataSeries`), or a
+`GeometricSolution`, in which case the error is computed from the invariant named by the
+`invariant` keyword (a key into `invariants(sol.problem)`, `:h` by default; a callable is
+also accepted). The axis label is derived from that name and can be overridden with
+`ylabel`. Returns a Makie `Figure`.
+"""
+function Diagnostics.plot_invariant_error(t::Union{TimeSeries, ScalarDataSeries}, Δ::DataSeries;
+        ylabel = nothing, invariant = :h, nplot = 1, nt = :auto, latex = true)
+    r  = _steprange(t, nplot, nt)
+    ts = [t[j] for j in r]
+    fig = Figure(size = (800, 400))
+    ax = Axis(fig[1, 1];
+        xlabel = latex ? L"t" : "t",
+        ylabel = ylabel === nothing ? _error_label(invariant, latex) : ylabel,
+    )
+    lines!(ax, ts, [Δ[j] for j in r])
+    xlims!(ax, ts[begin], ts[end])
+    return fig
+end
+
+function Diagnostics.plot_invariant_error(sol::GeometricSolution; invariant = :h, kwargs...)
+    Diagnostics.plot_invariant_error(sol.t, _invariant_error(sol, invariant); invariant, kwargs...)
+end
+
+"""
+    plot_invariant_drift(t, d; ylabel, nt, latex)
+    plot_invariant_drift(sol::GeometricSolution; invariant, ylabel, nt, latex)
+
+Scatter plot of the drift of an invariant (the maximum absolute error per interval, see
+`GeometricSolutions.compute_error_drift`) as a function of time. Keywords are those of
+[`plot_invariant_error`](@ref). Returns a `Figure`.
+"""
+function Diagnostics.plot_invariant_drift(t::Union{TimeSeries, ScalarDataSeries}, d::DataSeries;
+        ylabel = nothing, invariant = :h, nt = :auto, latex = true)
+    # drift data is interval-based; the first entry (index 0) is not part of it.
+    r  = 1:(nt === :auto ? ntime(t) : min(nt, ntime(t)))
+    ts = [t[j] for j in r]
+    fig = Figure(size = (800, 400))
+    ax = Axis(fig[1, 1];
+        xlabel = latex ? L"t" : "t",
+        ylabel = ylabel === nothing ? _drift_label(invariant, latex) : ylabel,
+    )
+    scatter!(ax, ts, [d[j] for j in r])
+    xlims!(ax, ts[begin], ts[end])
+    return fig
+end
+
+function Diagnostics.plot_invariant_drift(sol::GeometricSolution; invariant = :h, kwargs...)
+    interval = div(ntime(sol), 10)
+    Δ = _invariant_error(sol, invariant)
+    Diagnostics.plot_invariant_drift(compute_error_drift(sol.t, Δ, interval)...; invariant, kwargs...)
+end
+
+"""
     plot_energy_error(t, ΔH; nplot, nt, latex)
     plot_energy_error(sol::GeometricSolution; energy, nplot, nt, latex)
 
@@ -63,19 +141,11 @@ Plot the relative energy error `[H(t) - H(0)] / H(0)` as a function of time.
 Either pass a precomputed error series (`t::TimeSeries`, `ΔH::DataSeries`), or a
 `GeometricSolution`, in which case the error is computed from the solution's `:h`
 invariant (override with the `energy` keyword). Returns a Makie `Figure`.
+
+This is [`plot_invariant_error`](@ref) for the `:h` invariant.
 """
-function Diagnostics.plot_energy_error(t::Union{TimeSeries, ScalarDataSeries}, ΔH::DataSeries;
-        nplot = 1, nt = :auto, latex = true)
-    r  = _steprange(t, nplot, nt)
-    ts = [t[j] for j in r]
-    fig = Figure(size = (800, 400))
-    ax = Axis(fig[1, 1];
-        xlabel = latex ? L"t" : "t",
-        ylabel = latex ? L"[H(t) - H(0)] / H(0)" : "[H(t) - H(0)] / H(0)",
-    )
-    lines!(ax, ts, [ΔH[j] for j in r])
-    xlims!(ax, ts[begin], ts[end])
-    return fig
+function Diagnostics.plot_energy_error(t::Union{TimeSeries, ScalarDataSeries}, ΔH::DataSeries; kwargs...)
+    Diagnostics.plot_invariant_error(t, ΔH; invariant = :h, kwargs...)
 end
 
 function Diagnostics.plot_energy_error(sol::GeometricSolution; energy = nothing, kwargs...)
@@ -86,22 +156,14 @@ end
     plot_energy_drift(t, d; nt, latex)
 
 Scatter plot of the energy drift `ΔH` (maximum absolute energy error per interval,
-see `GeometricSolutions.compute_drift`) as a function of time. Returns a `Figure`.
+see `GeometricSolutions.compute_error_drift`) as a function of time. Returns a `Figure`.
+
+This is [`plot_invariant_drift`](@ref) for the `:h` invariant.
 """
-function Diagnostics.plot_energy_drift(t::Union{TimeSeries, ScalarDataSeries}, d::DataSeries;
-        nt = :auto, latex = true)
-    # drift data is interval-based; the first entry (index 0) is not part of it.
-    r  = 1:(nt === :auto ? ntime(t) : min(nt, ntime(t)))
-    ts = [t[j] for j in r]
-    fig = Figure(size = (800, 400))
-    ax = Axis(fig[1, 1];
-        xlabel = latex ? L"t" : "t",
-        ylabel = latex ? L"\Delta H" : "ΔH",
-    )
-    scatter!(ax, ts, [d[j] for j in r])
-    xlims!(ax, ts[begin], ts[end])
-    return fig
+function Diagnostics.plot_energy_drift(t::Union{TimeSeries, ScalarDataSeries}, d::DataSeries; kwargs...)
+    Diagnostics.plot_invariant_drift(t, d; invariant = :h, kwargs...)
 end
+
 function Diagnostics.plot_energy_drift(sol::GeometricSolution; energy = nothing, kwargs...)
     interval = div(ntime(sol), 10)
     ΔH = _energy_error(sol; energy)
@@ -142,6 +204,68 @@ end
 
 function Diagnostics.plot_lagrange_multiplier(sol::GeometricSolution; kwargs...)
     Diagnostics.plot_lagrange_multiplier(sol.t, sol.λ; kwargs...)
+end
+
+"""
+    plot_convergence(h, ε; order, ylabel, latex)
+
+Log-log plot of an error `ε` against the time step `h`, for a convergence study over a
+sequence of time steps. Passing `order = p` adds a reference line of slope `p`, anchored
+one factor of two above the first data point, so that the observed slope can be compared
+against the expected order of the method. Returns a Makie `Figure`.
+
+Data points with a vanishing error are dropped: they carry no information on a logarithmic
+axis and would make the axis limits degenerate. Methods that are exact for the diagnostic
+in question can therefore produce an empty plot.
+"""
+function Diagnostics.plot_convergence(h::AbstractVector, ε::AbstractVector;
+        order = nothing, ylabel = nothing, latex = true)
+    length(h) == length(ε) || throw(ArgumentError("h and ε must have the same length"))
+
+    keep = findall(>(0), abs.(ε))
+
+    fig = Figure(size = (600, 600))
+    ax = Axis(fig[1, 1];
+        xscale = log10,
+        yscale = log10,
+        xlabel = latex ? L"h" : "h",
+        ylabel = ylabel === nothing ? (latex ? L"\varepsilon" : "ε") : ylabel,
+    )
+
+    # The reference slope is anchored at twice the first *kept* error, matching the offset
+    # the study in GeometricExamples has always used, and spans the full range of h.
+    if order !== nothing && !isempty(keep)
+        offset = 2 * abs(ε[first(keep)])
+        h₀ = h[first(keep)]
+        lines!(ax, h, [offset * (hᵢ / h₀)^order for hᵢ in h];
+            linestyle = :dash, label = latex ? L"O(h^{%$order})" : "O(h^$order)")
+    end
+
+    if !isempty(keep)
+        scatterlines!(ax, h[keep], abs.(ε[keep]); label = latex ? L"\varepsilon" : "ε")
+        order === nothing || axislegend(ax; position = :rb)
+    end
+
+    return fig
+end
+
+"""
+    plot_order(h, p; latex)
+
+Plot the observed order of convergence `p` (typically `log2(ε(h) / ε(h/2))`) against the
+time step `h` on a logarithmic `h` axis. Returns a Makie `Figure`.
+"""
+function Diagnostics.plot_order(h::AbstractVector, p::AbstractVector; latex = true)
+    length(h) == length(p) || throw(ArgumentError("h and p must have the same length"))
+
+    fig = Figure(size = (600, 600))
+    ax = Axis(fig[1, 1];
+        xscale = log10,
+        xlabel = latex ? L"h" : "h",
+        ylabel = latex ? L"p" : "p",
+    )
+    scatterlines!(ax, h, p)
+    return fig
 end
 
 end

--- a/ext/PointVorticesPlots.jl
+++ b/ext/PointVorticesPlots.jl
@@ -1,0 +1,130 @@
+module PointVorticesPlots
+
+using Makie
+using GeometricEquations: invariants, parameters
+# Import GeometricSolutions symbols explicitly: `using Makie` also exports names
+# such as `TimeSeries`, which would otherwise clash with GeometricSolutions.
+using GeometricSolutions: ntime, compute_invariant_error
+
+import GeometricProblems.PointVortices
+import GeometricProblems.PointVorticesLinear
+
+# Downsampled integer time indices 0:nplot:nt (nt = :auto → all stored steps).
+_indices(sol, nplot, nt) = 0:nplot:(nt === :auto ? ntime(sol) : min(nt, ntime(sol)))
+
+_energy_error(sol, equ) = compute_invariant_error(sol.t, sol.q, parameters(equ), invariants(equ)[:h])[2]
+
+# Both vortices live in the same plane, so the state (q₁, q₂, q₃, q₄) is read as the two
+# positions (q₁, q₂) and (q₃, q₄). `_vortex(sol, idx, k)` returns the x/y coordinate pair of
+# vortex `k`.
+function _vortex(sol, idx, k)
+    i = 2k - 1
+    ([sol.q[j][i] for j in idx], [sol.q[j][i+1] for j in idx])
+end
+
+# The plot functions depend only on the solution `sol`, the equation `equ` (for the `:h`
+# invariant) and the keyword arguments, so the same implementations serve the deformed
+# `PointVortices` model and the linearised `PointVorticesLinear` one.
+
+"""
+    plot_phase_portrait(sol; nplot, nt, latex)
+
+Plot the trajectories of both point vortices in the `x`–`y` plane. Returns a Makie
+`Figure`.
+
+# Arguments
+- `sol <: GeometricSolution`
+
+# Keyword arguments
+- `nplot = 1`: plot every `nplot`-th time step
+- `nt = :auto`: last time step to plot
+- `latex = true`: use LaTeX axis labels
+"""
+function _plot_phase_portrait(sol; nplot = 1, nt = :auto, latex = true)
+    idx = _indices(sol, nplot, nt)
+    fig = Figure(size = (400, 400))
+    ax = Axis(fig[1, 1];
+        aspect = 1,
+        xlabel = latex ? L"x" : "x",
+        ylabel = latex ? L"y" : "y",
+    )
+    for k in 1:2
+        x, y = _vortex(sol, idx, k)
+        lines!(ax, x, y; label = latex ? L"\gamma_%$k" : "γ" * string(k))
+    end
+    axislegend(ax)
+    return fig
+end
+
+"""
+    plot_solution(sol, equ; nplot, nt, latex)
+
+Plot the trajectories of both point vortices next to the relative energy error of the
+solution. Returns a Makie `Figure`.
+"""
+function _plot_solution(sol, equ; nplot = 1, nt = :auto, latex = true)
+    idx = _indices(sol, nplot, nt)
+    ts  = [sol.t[j] for j in idx]
+    ΔH  = _energy_error(sol, equ)
+
+    fig = Figure(size = (800, 300))
+
+    ax_phase = Axis(fig[1, 1];
+        aspect = 1,
+        xlabel = latex ? L"x" : "x",
+        ylabel = latex ? L"y" : "y",
+    )
+    for k in 1:2
+        x, y = _vortex(sol, idx, k)
+        lines!(ax_phase, x, y)
+    end
+
+    ax_energy = Axis(fig[1, 2];
+        xlabel = latex ? L"t" : "t",
+        ylabel = latex ? L"[H(t) - H(0)] / H(0)" : "[H(t) - H(0)] / H(0)",
+    )
+    lines!(ax_energy, ts, [ΔH[j] for j in idx])
+    xlims!(ax_energy, ts[begin], ts[end])
+
+    return fig
+end
+
+"""
+    plot_traces(sol, equ; nplot, nt, latex)
+
+Plot the time traces of the four state components together with the relative energy error,
+stacked vertically. Returns a Makie `Figure`.
+"""
+function _plot_traces(sol, equ; nplot = 1, nt = :auto, latex = true)
+    idx = _indices(sol, nplot, nt)
+    ts  = [sol.t[j] for j in idx]
+    ΔH  = _energy_error(sol, equ)
+
+    # (x, y) of the first vortex, then of the second one.
+    ylabels = latex ? (L"x_1", L"y_1", L"x_2", L"y_2") : ("x₁", "y₁", "x₂", "y₂")
+
+    fig = Figure(size = (800, 1000))
+    for i in 1:4
+        ax = Axis(fig[i, 1]; ylabel = ylabels[i], xticklabelsvisible = false)
+        lines!(ax, ts, [sol.q[j][i] for j in idx])
+        xlims!(ax, ts[begin], ts[end])
+    end
+    ax_energy = Axis(fig[5, 1];
+        xlabel = latex ? L"t" : "t",
+        ylabel = latex ? L"[H(t) - H(0)] / H(0)" : "[H(t) - H(0)] / H(0)",
+    )
+    lines!(ax_energy, ts, [ΔH[j] for j in idx])
+    xlims!(ax_energy, ts[begin], ts[end])
+    return fig
+end
+
+# Attach the generic implementations to both problems' plot-function stubs.
+PointVortices.plot_phase_portrait(sol; kwargs...) = _plot_phase_portrait(sol; kwargs...)
+PointVortices.plot_solution(sol, equ; kwargs...) = _plot_solution(sol, equ; kwargs...)
+PointVortices.plot_traces(sol, equ; kwargs...) = _plot_traces(sol, equ; kwargs...)
+
+PointVorticesLinear.plot_phase_portrait(sol; kwargs...) = _plot_phase_portrait(sol; kwargs...)
+PointVorticesLinear.plot_solution(sol, equ; kwargs...) = _plot_solution(sol, equ; kwargs...)
+PointVorticesLinear.plot_traces(sol, equ; kwargs...) = _plot_traces(sol, equ; kwargs...)
+
+end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,15 +1,27 @@
 module Diagnostics
 
     export plot_energy_error, plot_energy_drift, plot_constraint_error, plot_lagrange_multiplier
+    export plot_invariant_error, plot_invariant_drift
+    export plot_convergence, plot_order
 
     # Shared helper used by the plotting extension to build subscripted axis labels.
     subscript(i::Integer) = i < 0 ? error("$i is negative") : join('₀' + d for d in reverse(digits(i)))
 
     # Generic diagnostic plots. The methods are implemented in the `DiagnosticsPlots`
     # extension, which is loaded together with `Makie`/`CairoMakie`.
+
+    # `plot_invariant_error` and `plot_invariant_drift` work for any invariant carried by a
+    # problem, addressed by its key in `invariants(problem)`. The energy variants are the
+    # `:h` special case, kept separate because it is by far the most common one.
+    function plot_invariant_error end
+    function plot_invariant_drift end
     function plot_energy_error end
     function plot_energy_drift end
     function plot_constraint_error end
     function plot_lagrange_multiplier end
+
+    # Convergence diagnostics over a sequence of time steps.
+    function plot_convergence end
+    function plot_order end
 
 end

--- a/src/point_vortices.jl
+++ b/src/point_vortices.jl
@@ -64,6 +64,8 @@ module PointVortices
         q[1] * ϑ₂(q) - q[2] * ϑ₁(q) +
         q[3] * ϑ₄(q) - q[4] * ϑ₃(q)
     end
+    # P depends only on q; provide the 4-arg method for (t, q, p, params) invariant contexts.
+    angular_momentum(t, q, p, params) = angular_momentum(t, q, params)
 
     # Formal (phase-space) Lagrangian L = ϑ(q)·v - H(q) for the non-canonical system.
     # Its Euler–Lagrange equations reproduce the point-vortex dynamics.
@@ -248,32 +250,39 @@ module PointVortices
     point_vortices_ϕ(ϕ, t, q, v, p, params) = point_vortices_ϕ(ϕ, t, q, p, params)
 
 
+    # The energy `h` and the angular momentum `p` are both conserved, so every formulation
+    # carries them and the generic `Diagnostics.plot_invariant_error(sol; invariant = :h/:p)`
+    # works out of the box.
+    const INVARIANTS = (h = hamiltonian, p = angular_momentum)
+
+
     function odeproblem(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
-        ODEProblem(point_vortices_v, timespan, timestep, q₀; parameters=parameters)
+        ODEProblem(point_vortices_v, timespan, timestep, q₀; invariants=INVARIANTS, parameters=parameters)
     end
 
     function iodeproblem(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, p₀;
-                    v̄=point_vortices_v, parameters=parameters)
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
     function idaeproblem(q₀=q₀, p₀=ϑ(q₀), λ₀=zero(q₀); timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         IDAEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_u, point_vortices_g,
                     point_vortices_ϕ, timespan, timestep, q₀, p₀, λ₀;
-                    v̄=point_vortices_v, parameters=parameters)
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
     function iodeproblem_dg(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, q₀;
-                    v̄=point_vortices_v, parameters=parameters)
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
     function lodeproblem_formal_lagrangian(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         LODEProblem(point_vortices_ϑ, point_vortices_f, point_vortices_g, ω, lagrangian,
-                    timespan, timestep, q₀, p₀; v̄=point_vortices_v, parameters=parameters)
+                    timespan, timestep, q₀, p₀;
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
 
@@ -300,5 +309,14 @@ module PointVortices
 
         (m, e)
     end
+
+
+    export plot_solution, plot_phase_portrait, plot_traces
+
+    # Problem-specific plots. The methods are implemented in the `PointVorticesPlots`
+    # extension, which is loaded together with `Makie`/`CairoMakie`.
+    function plot_solution end
+    function plot_phase_portrait end
+    function plot_traces end
 
 end

--- a/src/point_vortices_linear.jl
+++ b/src/point_vortices_linear.jl
@@ -50,6 +50,8 @@ module PointVorticesLinear
         q[1] * ϑ₂(q) - q[2] * ϑ₁(q) +
         q[3] * ϑ₄(q) - q[4] * ϑ₃(q)
     end
+    # P depends only on q; provide the 4-arg method for (t, q, p, params) invariant contexts.
+    angular_momentum(t, q, p, params) = angular_momentum(t, q, params)
 
     # Formal (phase-space) Lagrangian L = ϑ(q)·v - H(q) for the non-canonical system.
     # Its Euler–Lagrange equations reproduce the linearised point-vortex dynamics.
@@ -139,8 +141,14 @@ module PointVorticesLinear
         nothing
     end
 
+    # The energy `h` and the angular momentum `p` are both conserved, so every formulation
+    # carries them and the generic `Diagnostics.plot_invariant_error(sol; invariant = :h/:p)`
+    # works out of the box.
+    const INVARIANTS = (h = hamiltonian, p = angular_momentum)
+
+
     function odeproblem(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
-        ODEProblem(point_vortices_v, timespan, timestep, q₀; parameters=parameters)
+        ODEProblem(point_vortices_v, timespan, timestep, q₀; invariants=INVARIANTS, parameters=parameters)
     end
 
 
@@ -178,18 +186,19 @@ module PointVorticesLinear
     function iodeproblem(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, p₀;
-                    v̄=point_vortices_v, parameters=parameters)
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
     function iodeproblem_dg(q₀=q₀; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         IODEProblem(point_vortices_ϑ, point_vortices_f,
                     point_vortices_g, timespan, timestep, q₀, q₀;
-                    v̄=point_vortices_v, parameters=parameters)
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
     function lodeproblem_formal_lagrangian(q₀=q₀, p₀=ϑ(q₀); timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, parameters = default_parameters())
         LODEProblem(point_vortices_ϑ, point_vortices_f, point_vortices_g, ω, lagrangian,
-                    timespan, timestep, q₀, p₀; v̄=point_vortices_v, parameters=parameters)
+                    timespan, timestep, q₀, p₀;
+                    v̄=point_vortices_v, invariants=INVARIANTS, parameters=parameters)
     end
 
 
@@ -248,5 +257,14 @@ module PointVorticesLinear
 
         (p1, p2, p3, p4)
     end
+
+
+    export plot_solution, plot_phase_portrait, plot_traces
+
+    # Problem-specific plots. The methods are implemented in the `PointVorticesPlots`
+    # extension, which is loaded together with `Makie`/`CairoMakie`.
+    function plot_solution end
+    function plot_phase_portrait end
+    function plot_traces end
 
 end

--- a/test/plots_tests.jl
+++ b/test/plots_tests.jl
@@ -12,6 +12,8 @@ import GeometricProblems.LotkaVolterra2d as lv2
 import GeometricProblems.LotkaVolterra3d as lv3
 import GeometricProblems.LotkaVolterra4d as lv4
 import GeometricProblems.MasslessChargedParticle as mcp
+import GeometricProblems.PointVortices as pv
+import GeometricProblems.PointVorticesLinear as pvl
 
 # Loading CairoMakie activates the `Makie` weakdep, and with it all `*Plots`
 # extensions. These are smoke tests: each plot function must build and return a
@@ -63,6 +65,39 @@ import GeometricProblems.MasslessChargedParticle as mcp
         @test mcp.plot_phase_portrait(sol)  isa Figure
         @test mcp.plot_solution(sol, ode)   isa Figure
         @test mcp.plot_traces(sol, ode)     isa Figure
+    end
+
+    @testset "Point vortices" begin
+        for (name, mod) in (("deformed", pv), ("linear", pvl))
+            @testset "$(name)" begin
+                ode = mod.odeproblem()
+                sol = integrate(ode, Gauss(2))
+
+                @test mod.plot_phase_portrait(sol) isa Figure
+                @test mod.plot_solution(sol, ode)  isa Figure
+                @test mod.plot_traces(sol, ode)    isa Figure
+
+                # The point-vortex problems carry a second invariant, the angular
+                # momentum `:p`, which is what the generic diagnostics are for.
+                @test diag.plot_energy_error(sol)                       isa Figure
+                @test diag.plot_invariant_error(sol)                    isa Figure
+                @test diag.plot_invariant_error(sol; invariant = :p)    isa Figure
+                @test diag.plot_invariant_drift(sol; invariant = :p)    isa Figure
+                @test diag.plot_invariant_error(sol; invariant = mod.angular_momentum) isa Figure
+            end
+        end
+    end
+
+    @testset "Convergence" begin
+        h = [0.1, 0.05, 0.025, 0.0125]
+        ε = h .^ 2
+
+        @test diag.plot_convergence(h, ε)            isa Figure
+        @test diag.plot_convergence(h, ε; order = 2) isa Figure
+        # A method that is exact for the diagnostic gives a vanishing error everywhere,
+        # which has to yield an (empty) figure rather than a degenerate log axis.
+        @test diag.plot_convergence(h, zero(h); order = 2) isa Figure
+        @test diag.plot_order(h, fill(2.0, length(h)))     isa Figure
     end
 
     @testset "Harmonic oscillator" begin


### PR DESCRIPTION
## Summary

Three related changes, one commit each.

**Generic invariant diagnostics.** `Diagnostics.plot_invariant_error` and `plot_invariant_drift` plot the relative error of *any* invariant a problem carries, addressed either by its key in `invariants(problem)` (`:h` by default) or by passing the invariant function itself. Axis labels are derived from that name, with a `ylabel` override. `plot_energy_error` / `plot_energy_drift` are now the `:h` special case and keep their previous behaviour, signatures and labels.

Motivated by problems with more than one conserved quantity — the point vortices below, and the guiding-centre toroidal momentum in `ChargedParticleDynamics` — which previously each needed their own bespoke plotting code.

**Convergence diagnostics.** `plot_convergence(h, ε; order)` is a log-log error-over-timestep plot with an optional reference slope of the expected order; `plot_order(h, p)` plots the observed order. Data points with a vanishing error are dropped rather than making the log axis limits degenerate, so a method that is exact for the diagnostic yields an empty plot instead of an error.

**Point vortices.** Both `PointVortices` and `PointVorticesLinear` were missing invariant declarations entirely, so none of the generic diagnostics worked on their solutions. Every formulation now carries `invariants = (h = hamiltonian, p = angular_momentum)`, and `angular_momentum` gained the four-argument `(t, q, p, params)` method the implicit formulations evaluate invariants with. A new `PointVorticesPlots` Makie extension provides `plot_phase_portrait`, `plot_solution` and `plot_traces` for both modules, mirroring `MasslessChargedParticlePlots`; the implementations depend only on the solution and the equation, so one set serves the deformed and the linearised model.

This PR also bumps the version to **0.7.3**.

## Tests

`test/plots_tests.jl` gains a "Point vortices" testset that runs both modules through all three plot functions plus `plot_invariant_error` addressed by `:h`, by `:p` and by bare function, and a "Convergence" testset covering the all-zero-error edge case. The full suite passes locally (`Plotting extensions`: 41/41).

## Docs

`docs/src/diagnostics.md` lists the new generic and convergence plots and shows the angular momentum of a point-vortex solution as the non-energy example. `docs/src/point_vortices.md` now calls `plot_phase_portrait` instead of hand-rolling the figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)