### PR TITLE
Hand-write the TodaLattice equations of motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,49 @@ Categories: **Bug fixes** = code defects (typos, wrong API calls, crashes, bad i
   is no break-even — the symbolic route never earns its setup cost back, however long the run. (At
   `n = 10` the generated `v`, `ϑ` and `g` do win, being ten unrolled assignments against a broadcast;
   by `n = 130` they have lost that too.) `src/linear_wave.jl`.
+- **Toda lattice**: hand-written vector fields, the last of the three conversions. `hodeproblem`,
+  `lodeproblem`, `hodeensemble` and `lodeensemble` no longer generate the equations of motion
+  symbolically by default; they use in-place `v`, `f`, `ϑ`, `g` and `ω!` built on a shared `∇V!`
+  kernel. `hamiltonian_system` and `lagrangian_system` remain, and `symbolic = true` routes all four
+  constructors through them for cross-checking; the two agree exactly on `v`, `f`, `ϑ`, `g` and `ω`
+  and to one ulp on `H` and `L`.
+
+  The lattice is periodic, so with `Eₙ = exp(qₙ - qₙ₊₁)` the gradient is `∂V/∂qⱼ = α (Eⱼ - Eⱼ₋₁)`
+  with `E₀ ≡ E_N`. `∇V!` computes the wrap-around term `E_N` — which is also `E₀` — once and up
+  front, then makes a single pass carrying `Eⱼ₋₁` in a scalar and writing each output as it goes: no
+  allocation, one `exp` per site (which is the whole cost), and one entry, the last, peeled off. It
+  is correct for every `N ≥ 1`: at `N = 1` the only neighbour of the only point is itself, so `V` is
+  constant and `∇V` vanishes identically — the right answer, and the one the wrap-around is easiest
+  to get wrong at. Because no entry of the output is ever read back and `E_N` is taken before the
+  first write, the kernel is also correct when its output aliases the state, which the tests assert.
+
+  As with the linear wave the win is in *setup*, and for the same reason: EulerLagrange builds the
+  `2N × 2N` Lagrange two-form by symbolically differentiating a dense matrix — 160 k entries at the
+  default `Ñ = 200` — so `lagrangian_system(200, …)` takes **73 s** and emits **8.4 MB** of code for
+  an `ω` whose first evaluation costs a further **82 s**, all for a two-form no integrator evaluates
+  and that `check_methods` skips. Construction grows as `N^2.4` (0.43 s at `N = 32`, 2.6 s at
+  `N = 64`, 20 s at `N = 128`, 73 s at `N = 200`) and the generated `ω` as `N^2` (208 k characters at
+  `N = 32`, 3.4 M at `N = 128`, 8.4 M at `N = 200`); `hamiltonian_system` stays cheap throughout,
+  1.2 s at `N = 200`. The hand-written problems build in a tenth of a millisecond at any size.
+
+  Per call the picture differs from the linear wave, and not in the hand-written code's favour
+  everywhere. Both force functions are dominated by the `N` exponentials rather than by arithmetic,
+  so the **generated force stays ahead** — by 10% at `N = 8`, 12% at `N = 32`, 8% at `N = 128` and 5%
+  at `N = 200` — while the hand-written `H` and `L` are 1.3× faster at `N = 8` rising to 2.0× at
+  `N = 128`, and `v`, `ϑ` and `g` change places (generated ~2× ahead at `N = 8`, hand-written ~1.5×
+  ahead at `N = 128`). Writing `∇V!` as a single pass rather than filling the output with the `Eₙ` and
+  overwriting them buys a further 3–4% at every size, which narrows that gap without closing it.
+  There is therefore a real break-even here rather than none at all — it is just never reached: the
+  155 s of setup a `symbolic = true` LODE pays at `N = 200` takes **6.9 × 10⁹** force evaluations to
+  earn back, some six orders of magnitude beyond a default run. `src/toda_lattice.jl`.
+- **Toda lattice**: `lodeproblem` and `lodeensemble` no longer build a second, complete
+  `HamiltonianSystem` for the sole purpose of obtaining `v̄ = heqs.v`. The mass matrix is the
+  identity, so that function is `v .= p`, which is now written out. This was the last such call site
+  in the package; every other LODE already passed a hand-written `v̄`. `src/toda_lattice.jl`.
+- `benchmark/toda_lattice.jl`, backing the numbers above, in the shape of `benchmark/linear_wave.jl`:
+  agreement, construction and compile cost (one fresh process per lattice size), steady-state
+  per-call cost, break-even, and an end-to-end build-plus-integrate comparison.
+  `TODA_LATTICE_BENCH_FULL=1` waives the 90 s per-size budget and sweeps to the default `Ñ = 200`.
 - `benchmark/outer_solar_system.jl` and `benchmark/simplify_evaluation.jl`, backing the two changes
   above with construction time, generated-code size and per-call evaluation cost.
 - `benchmark/linear_wave.jl`, backing the linear-wave numbers above, and `benchmark/timing.jl`, the
@@ -159,8 +202,26 @@ depended on the old form doing what it claimed.
   constructors now also assert that the initial condition has `N + 2` components: the hand-written
   fields read the size off the state while the symbolic ones bake it in, so a mismatched `N` would
   otherwise mean two different systems depending on `symbolic`. `src/linear_wave.jl`.
+- **Toda lattice**: `hamiltonian` and `lagrangian` gained the same four-argument methods, recovering
+  `N = length(q)` (the lattice is periodic, so the state has exactly `N` components), and the four
+  constructors likewise assert that the initial condition has `N` of them. That assertion also
+  repairs the two-argument `hodeproblem(q₀, p₀)`/`lodeproblem(q₀, p₀)` forms, which sized themselves
+  with `length(q₀)` where the ensemble forms correctly used `_length(q₀)`: handed a vector of
+  samples they took the *number of samples* for the lattice size. And `lodeproblem`/`hodeproblem`
+  passed `parameters` raw to `lagrangian_system`/`hamiltonian_system` in one place and
+  `_parameters(parameters)` in another, so a vector of parameter sets reached `symbolize`
+  asymmetrically; both now use `_parameters`. `src/toda_lattice.jl`.
+- **Toda lattice**: removed the unused module-level `const Ω = compute_domain(Ñ, typeof(μ))`. It was
+  a plot domain, referenced nowhere in `src/`, `test/`, `docs/` or `benchmark/`, and a module-level
+  `Ω` that is *not* the two-form sitting next to the new `ω!` is a trap worth not setting.
+  `src/toda_lattice.jl`.
 
 ### Documentation
+- **Toda lattice**: the page gained the `@autodocs` block every other converted problem page has, so
+  that `potential`, `∇V!`, `ω!` and the four constructors are rendered at all. Without it the
+  `@ref` links in the module docstring — which *is* rendered, via `@docs` — resolve to nothing, and
+  an unresolved `@ref` is a fatal `:cross_references` error, so the docs build terminated before
+  rendering. `docs/src/toda_lattice.md`.
 - **Three-body problem**: the page now plots the figure-eight choreography instead of
   `hodeproblem(; timestep = .2)`. That call inherited the old default timespan `(0, 5)`, so every
   docs build integrated through the near-collision — 2554 solver warnings and an energy drift of
@@ -207,6 +268,27 @@ depended on the old form doing what it claimed.
 - **`LinearWave.lodeproblem` added to `test/lode_wiring_tests.jl`** as a regular Lagrangian
   (`2n × 2n` two-form), on a `N = 5` lattice. That file asks for every new `lodeproblem` to be listed;
   `LinearWave` was absent only because constructing it symbolically was too slow.
+- **`TodaLattice.lodeproblem` added to `test/lode_wiring_tests.jl`** for the same reason, also as a
+  regular Lagrangian on `N = 5`. Its default initial momentum is zero, which would leave `l`
+  degenerate, so the velocity is offset.
+- **`test/toda_lattice_tests.jl`: 16 assertions → 88.** The existing `N = 20` HODE/LODE and ensemble
+  agreement block is unchanged. Four testsets added, mirroring `linear_wave_tests.jl`: the two
+  default-size constructions with function-identity assertions
+  (`functions(prob).f === TodaLattice.toda_lattice_f` and friends, plus
+  `initialguess(lode).v === TodaLattice.v̄`), which are the cheapest possible guard that the default
+  path never routes through EulerLagrange again; a cross-check at `N = 5` of every generated function
+  against its hand-written counterpart, including the `2N × 2N` `ω`; an integration-agreement testset
+  against `symbolic = true` under `ImplicitMidpoint`; and a symbolic ensemble construction testset.
+  That last one exists because the ensembles are hand-written now, so
+  `test/eulerlagrange_ensembles_tests.jl` — which names this file as its `TodaLattice` counterpart —
+  would otherwise have lost that coverage entirely, the same trap the linear wave hit above.
+
+  `∇V!` is checked against a central finite difference of `potential`, which shares no code with it,
+  at `N = 1, 2, 3, 5, 12, 64`. The periodic wrap-around `E₀ ≡ E_N` is verified by nothing else, and
+  `N = 1` and `N = 2` are the sizes at which it collapses — at `N = 1` the only neighbour of the only
+  point is itself, so the gradient vanishes identically and the test asserts exactly that. At each of
+  those sizes the kernel is also called with its output aliased onto the state, which its single pass
+  makes correct and a return to a scratch-space formulation would silently break.
 - **`test/eulerlagrange_ensembles_tests.jl` now passes `symbolic = true`** to its three
   `LinearWave` ensemble constructions. Without it that testset would no longer touch EulerLagrange at
   all, which is the one thing the file exists to exercise. A second testset integrates the
@@ -252,9 +334,6 @@ depended on the old form doing what it claimed.
   exactly what EulerLagrange used to return.
 
 ### Known follow-ups
-- `TodaLattice` still has no hand-written vector fields, so at its default `N = 200` its `lodeproblem`
-  pays the same dense-`ω` construction cost the linear wave just shed. It also passes `v̄ = heqs.v`,
-  building an entire extra `HamiltonianSystem` for a function that is just `p`.
 - `LotkaVolterra3d` declares only `h` as an invariant, although `casimir` is conserved too;
   declaring it would make `Diagnostics.plot_invariant_error(sol; invariant = :c)` work out of the
   box.
@@ -320,7 +399,7 @@ depended on the old form doing what it claimed.
 ### Documentation
 - **Outer solar system**: the module described "the five outer planets (Jupiter, Saturn, Uranus,
   Neptune) and Pluto" — four planets and Pluto. Also documented that building the problem is very
-  slow (see *Known follow-ups*). `src/outer_solar_system.jl`.
+  slow, which 0.8.0's hand-written vector fields have since fixed. `src/outer_solar_system.jl`.
 - Moved the `plot_*` docstrings of the point-vortex and massless-charged-particle extensions from
   the private `_plot_*` helpers onto the public `Module.plot_*` methods, so that `?` and
   `@autodocs` find them. `ext/PointVorticesPlots.jl`, `ext/MasslessChargedParticlePlots.jl`.

--- a/benchmark/simplify_evaluation.jl
+++ b/benchmark/simplify_evaluation.jl
@@ -62,7 +62,8 @@ end
 
 # `simplify=false` has been the EulerLagrange default since 0.5, and these two are the only problems
 # here whose size is a free parameter. Both are measured on a small lattice, because construction
-# cost grows steeply with it — see `benchmark/linear_wave.jl` for how steeply.
+# cost grows steeply with it — see `benchmark/linear_wave.jl` and `benchmark/toda_lattice.jl` for how
+# steeply.
 const TODA_N = 8
 const WAVE_N = 8
 

--- a/benchmark/toda_lattice.jl
+++ b/benchmark/toda_lattice.jl
@@ -1,0 +1,411 @@
+# Benchmark for the TodaLattice equations of motion: hand-written vs symbolic (EulerLagrange).
+#
+#     julia --project=.    benchmark/toda_lattice.jl   # construction, compile and per-call cost
+#     julia --project=test benchmark/toda_lattice.jl   # additionally times a full integration
+#
+#     TODA_LATTICE_BENCH_FULL=1 julia --project=. benchmark/toda_lattice.jl   # sweep out to N = 200
+#
+# The companion of `benchmark/linear_wave.jl`, and the measurement that chose the default here too.
+# It answers five questions:
+#
+#   1. Do the hand-written and generated functions agree?
+#   2. What does the symbolic route cost to *build* and to *compile*, as a function of size?
+#   3. What does each function cost to *call*, once built?
+#   4. How many evaluations would it take for the symbolic route to earn its setup cost back?
+#   5. What does the difference come to over a whole integration?
+#
+# The state has exactly N components — unlike the linear wave, the Toda lattice is periodic and has
+# no boundary points — and the Lagrangian is regular, so EulerLagrange emits a 2N × 2N Lagrange
+# two-form. It builds that form by symbolically differentiating a *dense* matrix, which is what makes
+# the symbolic route scale as badly as it does. Note that the `ω` rows below measure something no
+# integrator ever calls — every `.ω` in GeometricIntegrators is a SPARK/VPRK tableau coefficient, the
+# one equation-`ω` call site is commented out, and `GeometricEquations.check_methods` skips `ω` —
+# which is precisely what makes the generated `ω` pure overhead.
+#
+# Where this differs from the linear wave is the potential itself: Toda's is a sum of N exponentials,
+# so both routes are dominated by `exp` rather than by arithmetic on differences. That does more than
+# narrow the per-call gap for the force — it reverses it, the generated force coming out 5-12% ahead
+# over N = 8 to 200. It changes nothing about the construction cost, which is what the default turns
+# on, and section 4 puts the two together: the break-even is 6.9e9 force evaluations at N = 200.
+#
+# `using EulerLagrange` is deliberately avoided: EulerLagrange is a dependency of the main project but
+# not of `test/Project.toml`, and this script has to run under both. `functions` is generic in
+# GeometricBase and re-exported by GeometricEquations, so the EulerLagrange methods dispatch anyway.
+
+using GeometricEquations: functions
+using GeometricProblems
+using Printf
+
+import GeometricProblems.TodaLattice as toda
+
+include("timing.jl")
+
+const PARAMS = toda.default_parameters()
+
+# A 5% difference in a hand-rolled microbenchmark is not a real difference; the same threshold
+# `simplify_evaluation.jl` uses.
+const THRESHOLD = 1.15
+
+const N_SWEEP = [4, 8, 16, 32, 64, 96, 128]
+const N_FULL = [160, 200]
+const FULL = get(ENV, "TODA_LATTICE_BENCH_FULL", "0") != "0"
+
+# Stop the sweep once a single size costs more than this, so the script stays runnable by default.
+const BUDGET = 90.0
+
+"""
+    state(N)
+
+Positions, momenta and velocities on `N` lattice points.
+
+The default initial momentum of this model is zero, which would make the force the only nontrivial
+thing measured and `L` numerically equal to `-V`. The momenta are therefore offset, and the
+positions perturbed off the bump so that no lattice difference is accidentally zero.
+"""
+function state(N)
+    q = collect(toda.compute_initial_q(toda.μ, N)) .+ 0.05 .* collect(1:N)
+    p = collect(range(0.1, 0.4, length = N))
+    # the mass matrix is the identity, so q̇ = p
+    return q, p, copy(p)
+end
+
+"""
+    comparisons(N, hameqs, lageqs)
+
+The functions an integrator calls, as `(label, generated, handwritten)` triples of thunks.
+
+Each thunk returns the output it wrote, so that `percall` can feed it to `sink!` and the call cannot
+be optimised away. Generated and hand-written write into separate buffers, so the same triple serves
+both the agreement check and the timings.
+"""
+function comparisons(N, hameqs, lageqs)
+    q, p, v = state(N)
+    gen, hand = zeros(N), zeros(N)
+    Ωgen, Ωhand = zeros(2N, 2N), zeros(2N, 2N)
+    λ = collect(range(0.1, 0.7, length = N))
+    return (
+        ("v = ∂H/∂p", () -> (hameqs.v(gen, 0.0, q, p, PARAMS); gen),
+                      () -> (toda.toda_lattice_v(hand, 0.0, q, p, PARAMS); hand)),
+        ("f = -∂H/∂q", () -> (hameqs.f(gen, 0.0, q, p, PARAMS); gen),
+                       () -> (toda.toda_lattice_f(hand, 0.0, q, p, PARAMS); hand)),
+        ("f = ∂L/∂q", () -> (lageqs.f(gen, 0.0, q, v, PARAMS); gen),
+                      () -> (toda.toda_lattice_f(hand, 0.0, q, v, PARAMS); hand)),
+        ("ϑ = ∂L/∂q̇", () -> (lageqs.ϑ(gen, 0.0, q, v, PARAMS); gen),
+                       () -> (toda.toda_lattice_ϑ(hand, 0.0, q, v, PARAMS); hand)),
+        ("g = λ", () -> (lageqs.g(gen, 0.0, q, v, λ, PARAMS); gen),
+                  () -> (toda.toda_lattice_g(hand, 0.0, q, v, λ, PARAMS); hand)),
+        ("ω (2N×2N)", () -> (lageqs.ω(Ωgen, 0.0, q, v, PARAMS); Ωgen),
+                      () -> (toda.ω!(Ωhand, 0.0, q, v, PARAMS); Ωhand)),
+        ("H", () -> hameqs.H(0.0, q, p, PARAMS),
+              () -> toda.hamiltonian(0.0, q, p, PARAMS)),
+        ("L", () -> lageqs.L(0.0, q, v, PARAMS),
+              () -> toda.lagrangian(0.0, q, v, PARAMS)),
+    )
+end
+
+# The construction sweep runs each size in a *fresh process*, because the cost of a generated
+# function's first call is badly order-dependent within one process: once anything has driven Julia
+# through this call path, later first calls come back nanoseconds instead of seconds, and the sweep
+# would report a multi-megabyte `ω` as free to compile. A subprocess per size is the only way to
+# measure what a user actually pays in a fresh session.
+#
+# Each worker does warm up `lagrangian_system` at N = 4 *without calling* the generated functions.
+# That excludes the one-off ~10 s of Symbolics compilation, which would otherwise swamp every row and
+# hide the scaling, and it was verified not to affect the first-call figures.
+const WORKER = raw"""
+    using GeometricEquations: functions
+    using GeometricProblems
+    import GeometricProblems.TodaLattice as toda
+
+    const P = toda.default_parameters()
+    el(f) = (GC.gc(); s = time(); r = f(); (time() - s, r))
+
+    toda.lagrangian_system(4, P)    # warm up Symbolics; deliberately never called
+
+    N = parse(Int, ARGS[1])
+    q = collect(toda.compute_initial_q(toda.μ, N)) .+ 0.05 .* collect(1:N)
+    v = collect(range(0.1, 0.4, length = N))
+    out = zeros(N)
+    Ω = zeros(2N, 2N)
+
+    t_hsys, _    = el(() -> toda.hamiltonian_system(N, P))
+    t_lsys, lsys = el(() -> toda.lagrangian_system(N, P))
+    t_hand, _    = el(() -> (toda.hodeproblem(N), toda.lodeproblem(N)))
+
+    eqs = functions(lsys)
+    t_f, _ = el(() -> eqs.f(out, 0.0, q, v, P))
+    t_ω, _ = el(() -> eqs.ω(Ω, 0.0, q, v, P))
+
+    println("RESULT ", join((t_hsys, t_lsys, t_hand, t_f, t_ω, length(string(eqs.ω.body))), " "))
+"""
+
+"Run the construction benchmark for one size in a fresh process."
+function measure_construction(N)
+    cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $WORKER $N`
+    for line in eachline(open(cmd))
+        startswith(line, "RESULT ") || continue
+        f = split(line)[2:end]
+        return (t_hsys = parse(Float64, f[1]), t_lsys = parse(Float64, f[2]),
+                t_hand = parse(Float64, f[3]), t_f = parse(Float64, f[4]),
+                t_ω = parse(Float64, f[5]), chars = parse(Int, f[6]))
+    end
+    error("worker for N = $N produced no result")
+end
+
+"Exponent `b` of a least-squares fit `t ≈ a · Nᵇ`, over the points with a usefully large `t`."
+function power_law(ns, ts)
+    pts = [(log(n), log(t)) for (n, t) in zip(ns, ts) if t > 10 * TIMER_RES]
+    length(pts) < 2 && return NaN
+    x̄ = sum(first, pts) / length(pts)
+    ȳ = sum(last, pts) / length(pts)
+    num = sum((x - x̄) * (y - ȳ) for (x, y) in pts)
+    den = sum((x - x̄) ^ 2 for (x, _) in pts)
+    return num / den
+end
+
+# =================================================================================================
+# 0. Warm-up
+#
+# Symbolics and EulerLagrange compile a great deal of their own code on first use. Without this, all
+# of it would land in the first row of the table below.
+# =================================================================================================
+
+let N = 4
+    hameqs = functions(toda.hamiltonian_system(N, PARAMS))
+    lageqs = functions(toda.lagrangian_system(N, PARAMS))
+    for (_, gen, hand) in comparisons(N, hameqs, lageqs)
+        sink!(gen())
+        sink!(hand())
+    end
+    toda.hodeproblem(N)
+    toda.lodeproblem(N)
+end
+
+@printf("\ntimer resolution: %.1f ns\n", 1e9 * TIMER_RES)
+
+# =================================================================================================
+# 1. Agreement
+#
+# The hand-written functions exist precisely to replace the generated ones, so nothing below this
+# section means anything unless they agree.
+# =================================================================================================
+
+println("\n", "="^100)
+println("1. Do the hand-written and generated functions agree?  (N = 5)")
+println("="^100)
+@printf("%-14s %14s %14s   %s\n", "function", "max|Δ|", "scale", "verdict")
+println("-"^100)
+
+let N = 5
+    hameqs = functions(toda.hamiltonian_system(N, PARAMS))
+    lageqs = functions(toda.lagrangian_system(N, PARAMS))
+    for (label, gen, hand) in comparisons(N, hameqs, lageqs)
+        a, b = gen(), hand()
+        Δ = maximum(abs, a .- b)
+        scale = maximum(abs, a)
+        ok = isapprox(a, b; rtol = 1e-10, atol = 1e-14)
+        @printf("%-14s %14.3e %14.3e   %s\n", label, Δ, scale, ok ? "agree" : "[MISMATCH]")
+    end
+end
+
+# `∇V!` is where the whole hand-written formulation could go wrong: the lattice is periodic, so the
+# gradient α (Eⱼ - Eⱼ₋₁) wraps around at j = 1, and that wrap-around is checked by nothing else.
+# Differentiate `potential` itself, which shares no code with `∇V!`. N = 1 and N = 2 are included
+# because they are the cases where the wrap-around collapses: at N = 1 the only neighbour of the only
+# point is itself (so V is constant and ∇V vanishes identically, which is the right answer), and at
+# N = 2 the forward and backward neighbours coincide.
+println("\n∇V! against a central finite difference of `potential`:")
+@printf("  %4s %14s %14s   %s\n", "N", "max|Δ|/scale", "scale", "verdict")
+for N in (1, 2, 3, 5, 12, 64)
+    q = collect(toda.compute_initial_q(toda.μ, N)) .+ 0.1 .* collect(1:N)
+    h = 1e-6
+    reference = zeros(N)
+    for j in 1:N
+        qp = copy(q); qp[j] += h
+        qm = copy(q); qm[j] -= h
+        reference[j] = (toda.potential(qp, PARAMS, N) - toda.potential(qm, PARAMS, N)) / 2h
+    end
+    kernel = zeros(N)
+    toda.∇V!(kernel, q, PARAMS, N)
+    scale = maximum(abs, reference)
+    relative = maximum(abs, kernel .- reference) / max(scale, one(scale))
+    # `scale` scales the gradient, and scale = -1 is what the force function uses
+    negated = zeros(N)
+    toda.∇V!(negated, q, PARAMS, N, -1)
+    verdict = relative < 1e-6 ? (negated ≈ -kernel ? "agree" : "[scale = -1 MISMATCH]") : "[MISMATCH]"
+    N == 1 && all(iszero, kernel) && (verdict *= "  (∇V ≡ 0 at N = 1)")
+    @printf("  %4d %14.3e %14.3e   %s\n", N, relative, scale, verdict)
+end
+
+# =================================================================================================
+# 2. Construction and compile cost
+#
+# The decisive table. `hodeproblem`/`lodeproblem` in their default (hand-written) form do no work
+# beyond wrapping a few function pointers, so their column is the baseline the symbolic columns are
+# to be read against.
+# =================================================================================================
+
+println("\n", "="^116)
+println("2. What does the symbolic route cost to build and to compile?  (one fresh process per size)")
+println("="^116)
+@printf("%4s %11s %11s %14s %11s %11s %12s\n",
+        "N", "ham_system", "lag_system", "hand-written", "1st gen f", "1st gen ω", "chars gen ω")
+println("-"^116)
+
+const SWEEP_N = Int[]
+const SWEEP_LAG = Float64[]
+const SWEEP_OMEGA_CHARS = Float64[]
+const SWEEP_SETUP = Float64[]
+
+for N in (FULL ? vcat(N_SWEEP, N_FULL) : N_SWEEP)
+    r = measure_construction(N)
+
+    # The hand-written column is in µs: it builds two problems out of function pointers, which is
+    # five orders of magnitude away from everything beside it.
+    @printf("%4d %9.3f s %9.3f s %11.1f µs %9.3f s %9.3f s %12d\n",
+            N, r.t_hsys, r.t_lsys, 1e6 * r.t_hand, r.t_f, r.t_ω, r.chars)
+    flush(stdout)
+
+    push!(SWEEP_N, N)
+    push!(SWEEP_LAG, r.t_lsys)
+    push!(SWEEP_OMEGA_CHARS, r.chars)
+    # everything a user pays before the first useful step of a `symbolic = true` LODE
+    push!(SWEEP_SETUP, r.t_lsys + r.t_f + r.t_ω)
+
+    # The budget keeps the default run affordable. Opting in with TODA_LATTICE_BENCH_FULL waives it —
+    # going all the way to the default Ñ = 200 is the whole point of asking for the full sweep.
+    total = r.t_hsys + r.t_lsys + r.t_f + r.t_ω
+    if !FULL && total > BUDGET
+        @printf("  (stopping the sweep: N = %d alone cost %.0f s, over the %.0f s budget;\n", N, total, BUDGET)
+        println("   set TODA_LATTICE_BENCH_FULL=1 to go all the way to N = 200)")
+        break
+    end
+end
+
+let b_lag = power_law(SWEEP_N, SWEEP_LAG), b_chars = power_law(SWEEP_N, SWEEP_OMEGA_CHARS)
+    println()
+    @printf("`lagrangian_system` grows as N^%.2f, the generated `ω` as N^%.2f.\n", b_lag, b_chars)
+    if !FULL && !isempty(SWEEP_N)
+        scale = toda.Ñ / last(SWEEP_N)
+        @printf("Extrapolated to the default Ñ = %d: `lagrangian_system` ≈ %.0f s, `ω` ≈ %.1f MB of code.\n",
+                toda.Ñ, last(SWEEP_LAG) * scale^b_lag,
+                last(SWEEP_OMEGA_CHARS) * scale^b_chars / 1e6)
+        println("(Measured directly with TODA_LATTICE_BENCH_FULL=1: see the module docstring.)")
+    end
+end
+
+# =================================================================================================
+# 3. Steady-state per-call cost
+# =================================================================================================
+
+println("\n", "="^116)
+println("3. What does each function cost to call, once built?")
+println("="^116)
+@printf("%4s %-14s %13s %13s %8s %9s   %s\n",
+        "N", "function", "generated", "hand-written", "ratio", "reliable", "verdict")
+println("-"^116)
+
+# (N, label, ratio, t_generated, t_handwritten) for the break-even analysis below
+const CALLS = Tuple{Int,String,Float64,Float64,Float64}[]
+
+# Capped at 128: this section has to build the symbolic systems *in process*, and the per-call ratios
+# are already unambiguous by then. Going to 200 here would add minutes to say the same thing.
+for N in unique([8, isempty(SWEEP_N) ? 8 : min(128, last(SWEEP_N))])
+    hameqs = functions(toda.hamiltonian_system(N, PARAMS))
+    lageqs = functions(toda.lagrangian_system(N, PARAMS))
+    for (label, gen, hand) in comparisons(N, hameqs, lageqs)
+        gen(); hand()   # compile before timing
+        t_gen, ok_gen = percall(gen)
+        t_hand, ok_hand = percall(hand)
+        ratio = t_gen / t_hand
+        verdict = if !(ok_gen && ok_hand)
+            "below timer resolution"
+        elseif ratio > THRESHOLD
+            "hand-written faster"
+        elseif ratio < 1 / THRESHOLD
+            "generated faster"
+        else
+            "--"
+        end
+        label == "ω (2N×2N)" && (verdict *= "  (never called)")
+        @printf("%4d %-14s %10.4f µs %10.4f µs %8.2f %9s   %s\n",
+                N, label, 1e6 * t_gen, 1e6 * t_hand, ratio, ok_gen && ok_hand, verdict)
+        ok_gen && ok_hand && push!(CALLS, (N, label, ratio, t_gen, t_hand))
+    end
+    flush(stdout)
+end
+
+# =================================================================================================
+# 4. Break-even
+# =================================================================================================
+
+println("\n", "="^100)
+println("4. How many evaluations would the symbolic route need to earn its setup cost back?")
+println("="^100)
+
+let forces = filter(c -> startswith(c[2], "f "), CALLS)
+    if isempty(forces) || isempty(SWEEP_SETUP)
+        println("not enough reliable measurements")
+    else
+        N, label, ratio, t_gen, t_hand = last(forces)
+        Δsetup = last(SWEEP_SETUP)
+        @printf("At N = %d, `symbolic = true` costs %.1f s of setup before the first step.\n",
+                last(SWEEP_N), Δsetup)
+        @printf("Its `%s` then costs %.4f µs per call against the hand-written %.4f µs.\n",
+                label, 1e6 * t_gen, 1e6 * t_hand)
+        if N != last(SWEEP_N)
+            @printf("""
+(Those per-call figures are from N = %d, the largest size section 3 measures in process. The
+ per-call difference grows with N, so the break-even below is an over-estimate — by roughly the
+ ratio of the two sizes, which leaves its order of magnitude untouched.)\n""", N)
+        end
+        if t_gen < t_hand
+            @printf("Break-even: %.3g evaluations.\n", Δsetup / (t_hand - t_gen))
+        else
+            println("""
+The generated code is the *slower* one here, so there is no break-even: the symbolic route never
+earns its setup cost back, however long the run.""")
+        end
+    end
+end
+
+# =================================================================================================
+# 5. End to end
+#
+# The only measurement that combines setup and per-call cost the way a user experiences them.
+# =================================================================================================
+
+println("\n", "="^100)
+println("5. End-to-end: building and integrating a LODE")
+println("="^100)
+
+"Total wall clock, build plus integrate, each way. `GI` is the GeometricIntegrators module."
+function integration_section(GI, N; warmup = false)
+    # The very first `integrate` of the session compiles a large part of GeometricIntegrators, which
+    # would otherwise land on whichever branch happens to run first and make the two incomparable.
+    if warmup
+        GI.integrate(toda.lodeproblem(4), GI.ImplicitMidpoint())
+        GI.integrate(toda.lodeproblem(4; symbolic = true), GI.ImplicitMidpoint())
+    end
+    for symbolic in (false, true)
+        t_build, prob = elapsed(() -> toda.lodeproblem(N; symbolic = symbolic))
+        t_first, _ = elapsed(() -> GI.integrate(prob, GI.ImplicitMidpoint()))
+        t_warm, _ = elapsed(() -> GI.integrate(prob, GI.ImplicitMidpoint()))
+        @printf("  N=%3d  symbolic=%-5s  build %8.3f s   integrate %7.3f s (warm %7.3f s)   total %8.3f s\n",
+                N, symbolic, t_build, t_first, t_warm, t_build + t_first)
+        flush(stdout)
+    end
+end
+
+if Base.find_package("GeometricIntegrators") === nothing
+    println("""
+  skipped: GeometricIntegrators is a test-only dependency and is not in this environment.
+  Re-run with `julia --project=test benchmark/toda_lattice.jl` to include this section.""")
+else
+    @eval using GeometricIntegrators
+    # `@eval using` bumps the world age within this same top-level expression
+    Base.invokelatest(integration_section, GeometricIntegrators, 8; warmup = true)
+    Base.invokelatest(integration_section, GeometricIntegrators, 64)
+end
+
+@printf("\n(sink checksum %g -- printed only so the timed calls cannot be optimised away)\n\n", SINK[])

--- a/docs/src/toda_lattice.md
+++ b/docs/src/toda_lattice.md
@@ -74,6 +74,11 @@ fig
 GeometricProblems.TodaLattice
 ```
 
+```@autodocs
+Modules = [GeometricProblems.TodaLattice]
+Order   = [:constant, :type, :macro, :function]
+```
+
 ```@bibliography
 Pages = []
 

--- a/src/toda_lattice.jl
+++ b/src/toda_lattice.jl
@@ -3,7 +3,34 @@ The Toda lattice is a model for a one-dimensional crystal named after its discov
 
 It is a prime example of a non-trivial completely integrable system.
 
-The only system parameters are the *number of points* ``N`` in the periodic lattice and ``\alpha`` which adjusts the strength of the interactions in the lattice.
+It is configured by the *number of points* ``N`` in the periodic lattice and by ``\alpha``, which
+adjusts the strength of the interactions in the lattice.
+
+Like the number of interior points of `LinearWave`, ``N`` fixes the *size* of the system: it sets
+the number of degrees of freedom and the summation bounds, so it cannot survive `symbolize` and
+hence cannot be a system parameter. It is instead a leading positional argument of the problem
+constructors, defaulting to `Ñ = 200`, and `hamiltonian`/`lagrangian` take it as a trailing
+argument. The only system parameter proper is ``\alpha``.
+
+`hodeproblem`, `lodeproblem`, `hodeensemble` and `lodeensemble` use hand-written vector fields by
+default: in-place `v`, `f`, `ϑ`, `g` and `ω!` over a shared [`∇V!`](@ref) kernel. Passing
+`symbolic = true` generates the equations of motion with EulerLagrange via [`hamiltonian_system`](@ref)
+or [`lagrangian_system`](@ref) instead, which agrees to round-off and is kept for cross-checking.
+
+The symbolic route is unusable at the default size. EulerLagrange builds the ``2N × 2N`` Lagrange
+two-form by symbolically differentiating a *dense* matrix, which at ``N = 200`` is 160 k entries:
+`lagrangian_system(200, …)` takes 73 s and emits 8.4 MB of code whose first `ω` evaluation costs a
+further 82 s — all for a two-form that no integrator in GeometricIntegrators ever evaluates and that
+`GeometricEquations.check_methods` skips. Construction grows as ``N^{2.4}`` and the generated `ω` as
+``N^2``, while `hodeproblem`/`lodeproblem` in their default form build in a tenth of a millisecond at
+any size.
+
+Per call the two are much closer than for the linear wave, because both force functions are dominated
+by the ``N`` exponentials rather than by arithmetic: the generated force is in fact 5–12%
+*faster* over ``N = 8`` to ``200``, while the hand-written `H` and `L` are 1.3–2× faster and `v`, `ϑ`
+and `g` change places with size. So the 155 s of setup a `symbolic = true` LODE pays at ``N = 200``
+would take 6.9 × 10⁹ force evaluations to earn back — around six orders of magnitude more than a
+default run performs. See `benchmark/toda_lattice.jl`.
 """
 module TodaLattice
 
@@ -21,58 +48,292 @@ default_parameters(::Type{T}=Float64) where {T} = (
     α=T(0.64),
 )
 
+@doc raw"""
+    potential(q, parameters, N)
+
+The exponential nearest-neighbour interaction of the periodic Toda lattice on `N` points,
+
+```math
+V(q) = \alpha \sum_{n = 1}^{N} e^{q_n - q_{n+1}}, \qquad q_{N+1} \equiv q_1 .
+```
+
+Both the Hamiltonian and the Lagrangian take `N` as a trailing argument (as in `LinearWave`) rather
+than reading it from `parameters`: it fixes the number of degrees of freedom and the summation
+bounds, so it has to be a plain integer and cannot survive `symbolize`.
+"""
 function potential(q, params, N)
     params.α * sum(exp(q[n] - q[n%N+1]) for n in 1:N)
+end
+
+@doc raw"""
+    ∇V!(dV, q, parameters, N, scale = 1)
+
+`scale` times the gradient ``∂V/∂q`` of the periodic Toda [`potential`](@ref), written into `dV`.
+`scale = -1` gives the force ``-∂V/∂q`` directly, which is what the force functions want and saves
+the extra sweep over the output that negating afterwards would cost.
+
+Writing ``E_n = e^{q_n - q_{n+1}}`` with cyclic indices, ``q_j`` enters ``V = \alpha \sum_n E_n``
+with ``+1`` in the term ``n = j`` and with ``-1`` in the term ``n = j - 1``, so
+
+```math
+\frac{∂V}{∂q_j} = \alpha \, (E_j - E_{j-1}), \qquad E_0 \equiv E_N .
+```
+
+``E_N`` is both the last term and ``E_0``, so it is computed once, before anything is written, and
+kept in a scalar; the loop then carries ``E_{j-1}`` in a second scalar and writes ``∂V/∂q_j`` as it
+goes. So the kernel makes a single pass, allocates nothing, evaluates each exponential exactly once
+— the expensive part — and never reads an entry of `dV` back, which is what makes it safe even when
+`dV` aliases `q`.
+
+The one entry that has to be peeled off is the last, and that is also the only case analysis: the
+expression is otherwise correct for every ``N ≥ 1``. At ``N = 1`` the loop body never runs and
+``E_1 = e^0 = 1`` leaves ``∂V/∂q_1 = c \, (E_1 - E_1) = 0``, which is right, since ``V`` is then
+constant.
+
+The cyclic wrap-around is the one thing here that is easy to get wrong and that nothing else checks,
+so `test/toda_lattice_tests.jl` verifies this against a central finite difference of
+[`potential`](@ref), which shares no code with it, at several `N` including `N = 1` and `N = 2` — and
+at each of them with `dV` aliased onto `q`, which is the property the single pass buys.
+"""
+function ∇V!(dV, q, parameters, N, scale = 1)
+    @unpack α = parameters
+
+    c = scale * α
+
+    @inbounds begin
+        # the periodic wrap-around term, which is both E_N and E₀, computed before the first write so
+        # that q[1] is still intact even if dV aliases q
+        Eₙ = exp(q[N] - q[1])
+
+        # ∂V/∂q_j = α (E_j - E_{j-1}), carrying E_{j-1} in a scalar
+        Eₚ = Eₙ                         # E₀ ≡ E_N
+        for j in 1 : (N - 1)
+            Eⱼ = exp(q[j] - q[j + 1])
+            dV[j] = c * (Eⱼ - Eₚ)
+            Eₚ = Eⱼ
+        end
+        dV[N] = c * (Eₙ - Eₚ)           # Eₚ is E_{N-1} by now
+    end
+    nothing
 end
 
 hamiltonian(t, q, p, params, N) = p ⋅ p / 2 + potential(q, params, N)
 lagrangian(t, q, q̇, params, N) = q̇ ⋅ q̇ / 2 - potential(q, params, N)
 
+# GeometricEquations requires a HODE's `H` and a LODE's `l` to be callable as (t, q, p, params);
+# see `GeometricEquations.check_methods`. The state has exactly N components, so the lattice size can
+# be read off it and need not be closed over. `hamiltonian_system`/`lagrangian_system` keep calling
+# the five-argument methods, so that the summation bounds stay a plain integer, as `symbolize`
+# requires.
+hamiltonian(t, q, p, params) = hamiltonian(t, q, p, params, length(q))
+lagrangian(t, q, q̇, params) = lagrangian(t, q, q̇, params, length(q))
+
 const DEFAULT_TIMESTEP = 0.1
 const DEFAULT_TIMESPAN = (0.0, 120.0)
 
 # parameter for the default initial conditions
-const Ñ = 200
+const Ñ = 200
 const μ = 0.3
 
-const q₀ = compute_initial_q(μ, Ñ)
+const q₀ = compute_initial_q(μ, Ñ)
 const p₀ = zero(q₀)
-const Ω = compute_domain(Ñ, typeof(μ))
 
 
-function hamiltonian_system(N, parameters)
+# -------------------------------------------------------------------------------------------------
+# Hand-written vector fields
+#
+# These are what the four problem and ensemble constructors use by default. They follow the pattern
+# of the other hand-written problems in this package (see `linear_wave.jl` and
+# `outer_solar_system.jl`), including the extra arity methods GeometricEquations calls.
+#
+# None of them takes `N`: the state has exactly N components, so N = length(q). That makes them
+# size-agnostic, which is the whole point — the symbolic route has to be rebuilt per size.
+# -------------------------------------------------------------------------------------------------
+
+# In-place velocity estimate from momentum. The mass matrix is the identity, so q̇ = p — the same
+# expression as ∂H/∂p, hence also the initial guess the LODE wants. This replaces the second, full
+# `HamiltonianSystem` the LODE constructors used to build purely to obtain this one function.
+function v̄(v, t, q, p, params)
+    v .= p
+    nothing
+end
+
+# ∂H/∂p = p
+toda_lattice_v(v, t, q, p, params) = v̄(v, t, q, p, params)
+
+# -∂H/∂q = -∂V/∂q, and ∂L/∂q = -∂V/∂q as well, so the Hamiltonian and Lagrangian force functions
+# coincide and differ only in whether the third slot holds p or q̇.
+function toda_lattice_f(f, t, q, w, params)
+    ∇V!(f, q, params, length(q), -1)
+    nothing
+end
+
+# ϑ = ∂L/∂q̇ = q̇
+function toda_lattice_ϑ(Θ, t, q, w, params)
+    Θ .= w
+    nothing
+end
+
+# Projection direction for enforcing p = ϑ(q, q̇). The Lagrangian is regular, so the constraint is
+# non-degenerate and the projection acts in every direction; as in `linear_wave.jl` and
+# `outer_solar_system.jl` the multiplier absorbs the (here identity) mass matrix, giving g = λ.
+function toda_lattice_g(g, t, q, λ, params)
+    g .= λ
+    nothing
+end
+
+toda_lattice_g(g, t, q, w, λ, params) = toda_lattice_g(g, t, q, λ, params)
+
+@doc raw"""
+    ω!(Ω, t, q, params)
+
+The Lagrange two-form ``ω = dθ`` of this regular Lagrangian, where ``θ = ϑ_i \, dq^i``.
+
+A regular Lagrangian is a second-order system of ``N`` equations, equivalent to a first-order system
+of ``2N``, so `Ω` is the ``2N × 2N`` form on ``(q, \dot q)``. In block form it is
+``[∂ϑ_i/∂q_j - ∂ϑ_j/∂q_i \; -M^T; \; M \; 0]``; since ``ϑ = ∂L/∂\dot q = \dot q`` depends on the
+velocities alone and the mass matrix is the identity, the upper-left block vanishes and what remains
+is the canonical ``[0 \; -I; \; I \; 0]``.
+
+This is the convention EulerLagrange's `LagrangianSystem` produces, so `lodeproblem` agrees whether
+or not `symbolic = true`. Note that no integrator in GeometricIntegrators evaluates `ω` and
+`GeometricEquations.check_methods` skips it — which is what makes the 8.4 MB of code EulerLagrange
+emits for it at the default size, and the 82 s its first evaluation then costs, pure overhead.
+"""
+function ω!(Ω, t, q, params)
+    n = length(q)
+    fill!(Ω, zero(eltype(Ω)))
+    @inbounds for i in 1 : n
+        Ω[i, n + i] = -one(eltype(Ω))
+        Ω[n + i, i] = +one(eltype(Ω))
+    end
+    nothing
+end
+
+# LODE/LDAE evaluate the two-form with an extra velocity slot; ω depends on neither q nor q̇.
+ω!(Ω, t, q, w, params) = ω!(Ω, t, q, params)
+
+
+# -------------------------------------------------------------------------------------------------
+# Symbolic formulation (EulerLagrange)
+#
+# Kept for cross-checking the hand-written functions above, and reachable via `symbolic = true`.
+# `hamiltonian_system` is comparatively cheap; `lagrangian_system` is not, because EulerLagrange
+# differentiates a dense (2N)×(2N) matrix for `ω` and runs `build_function` over all 160 k entries of
+# it at the default size.
+# -------------------------------------------------------------------------------------------------
+
+"""
+    hamiltonian_system(N, parameters)
+
+The EulerLagrange `HamiltonianSystem` for the Toda lattice on `N` points, from which
+`hodeproblem(…; symbolic = true)` takes its `v`, `f` and `H`.
+
+Far cheaper than [`lagrangian_system`](@ref) at every size, since a Hamiltonian system carries no
+two-form — 1.2 s at the default `Ñ = 200`, against a tenth of a millisecond for the hand-written
+route.
+"""
+function hamiltonian_system(N::Int, parameters::NamedTuple)
     t, q, p = hamiltonian_variables(N)
     sparams = symbolize(parameters)
     HamiltonianSystem(hamiltonian(t, q, p, sparams, N), t, q, p, sparams; nanmath = true)
 end
 
-function lagrangian_system(N, parameters)
+"""
+    lagrangian_system(N, parameters)
+
+The EulerLagrange `LagrangianSystem` for the Toda lattice on `N` points, from which
+`lodeproblem(…; symbolic = true)` takes its `ϑ`, `f`, `g`, `ω` and `L`.
+
+This is the expensive one: it builds the ``2N × 2N`` two-form by differentiating a dense matrix, so
+its cost grows as ``N^{2.4}`` and reaches 73 s at the default `Ñ = 200` — followed by another 82 s
+the first time the generated `ω` is evaluated. See the module docstring and
+`benchmark/toda_lattice.jl`.
+"""
+function lagrangian_system(N::Int, parameters::NamedTuple)
     t, x, v = lagrangian_variables(N)
     sparams = symbolize(parameters)
     LagrangianSystem(lagrangian(t, x, v, sparams, N), t, x, v, sparams; nanmath = true)
 end
 
+# Build the symbolic system from a single parameter set, while a vector of parameter
+# sets is passed on to the ensemble unchanged (see issue #64).
 _parameters(p::NamedTuple) = p
-_parameters(p::AbstractVector{<:NamedTuple}) = p[begin]
+_parameters(p::AbstractVector) = p[begin]
 
+# The state has exactly N components, so an initial condition of length n corresponds to N = n. The
+# ensemble constructors are handed a vector of samples instead of a single one.
 _length(q::AbstractArray{<:Number}) = length(q)
 _length(q::AbstractVector{<:AbstractArray}) = length(q[begin])
 
+# The hand-written vector fields read the lattice size off the state while the symbolic ones have it
+# baked in, so an `N` that disagrees with the initial condition would silently mean two different
+# systems depending on `symbolic`. Reject it up front.
+function _check_size(N, q₀, p₀)
+    @assert _length(q₀) == N "initial condition has $(_length(q₀)) components, expected N = $N"
+    @assert _length(p₀) == N "initial condition has $(_length(p₀)) components, expected N = $N"
+    nothing
+end
+
 """
-Hamiltonian problem for the Toda lattice.
+    hodeproblem(N, q₀, p₀; timespan, timestep, parameters, symbolic)
+
+Hamiltonian problem for the Toda lattice on `N` points.
+
+Constructor with default arguments:
+```
+hodeproblem(
+    N  = $(Ñ),
+    q₀ = compute_initial_q(μ, N),
+    p₀ = zero(q₀);
+    timespan   = $(DEFAULT_TIMESPAN),
+    timestep   = $(DEFAULT_TIMESTEP),
+    parameters = $(default_parameters()),
+    symbolic   = false
+)
+```
+
+With `symbolic = true` the equations of motion are generated with EulerLagrange via
+[`hamiltonian_system`](@ref) instead of using the hand-written vector fields. The two agree to
+round-off; the symbolic route is kept for cross-checking and costs 1.2 s to build at `N = 200`.
 """
-function hodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
-    HODEProblem(hamiltonian_system(N, parameters), timespan, timestep, q₀, p₀; parameters=parameters)
+function hodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀);
+                     timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP,
+                     parameters=default_parameters(), symbolic=false)
+    _check_size(N, q₀, p₀)
+    if symbolic
+        HODEProblem(hamiltonian_system(N, _parameters(parameters)), timespan, timestep, q₀, p₀;
+                    parameters=parameters)
+    else
+        HODEProblem(toda_lattice_v, toda_lattice_f, hamiltonian,
+                    timespan, timestep, q₀, p₀; parameters=parameters)
+    end
 end
 
 function hodeproblem(q₀, p₀; kwargs...)
     @assert length(q₀) == length(p₀)
-    hodeproblem(length(q₀), q₀, p₀; kwargs...)
+    hodeproblem(_length(q₀), q₀, p₀; kwargs...)
 end
 
-function hodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
-    eqs = functions(hamiltonian_system(N, _parameters(parameters)))
-    HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters=parameters)
+"""
+    hodeensemble(N, q₀, p₀; timespan, timestep, parameters, symbolic)
+
+Hamiltonian ensemble for the Toda lattice (varying initial conditions and/or parameters).
+
+Takes the same arguments as [`hodeproblem`](@ref), with `q₀`, `p₀` and/or `parameters` given as
+vectors of samples.
+"""
+function hodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀);
+                      timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP,
+                      parameters=default_parameters(), symbolic=false)
+    _check_size(N, q₀, p₀)
+    if symbolic
+        eqs = functions(hamiltonian_system(N, _parameters(parameters)))
+        HODEEnsemble(eqs.v, eqs.f, eqs.H, timespan, timestep, q₀, p₀; parameters=parameters)
+    else
+        HODEEnsemble(toda_lattice_v, toda_lattice_f, hamiltonian,
+                     timespan, timestep, q₀, p₀; parameters=parameters)
+    end
 end
 
 function hodeensemble(q₀, p₀; kwargs...)
@@ -81,22 +342,66 @@ function hodeensemble(q₀, p₀; kwargs...)
 end
 
 """
-Lagrangian problem for the Toda lattice.
+    lodeproblem(N, q₀, p₀; timespan, timestep, parameters, symbolic)
+
+Lagrangian problem for the Toda lattice on `N` points.
+
+Constructor with default arguments:
+```
+lodeproblem(
+    N  = $(Ñ),
+    q₀ = compute_initial_q(μ, N),
+    p₀ = zero(q₀);
+    timespan   = $(DEFAULT_TIMESPAN),
+    timestep   = $(DEFAULT_TIMESTEP),
+    parameters = $(default_parameters()),
+    symbolic   = false
+)
+```
+
+With `symbolic = true` the equations of motion are generated with EulerLagrange via
+[`lagrangian_system`](@ref) instead of using the hand-written vector fields. The two agree to
+round-off, but the symbolic route takes 73 s to build at `N = 200`, and 155 s in all before the
+first step — see the module docstring.
 """
-function lodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
-    heqs = functions(hamiltonian_system(N, _parameters(parameters)))
-    LODEProblem(lagrangian_system(N, parameters), timespan, timestep, q₀, p₀; parameters=parameters, v̄=heqs.v)
+function lodeproblem(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀);
+                     timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP,
+                     parameters=default_parameters(), symbolic=false)
+    _check_size(N, q₀, p₀)
+    if symbolic
+        LODEProblem(lagrangian_system(N, _parameters(parameters)), timespan, timestep, q₀, p₀;
+                    v̄=v̄, parameters=parameters)
+    else
+        LODEProblem(toda_lattice_ϑ, toda_lattice_f, toda_lattice_g, ω!, lagrangian,
+                    timespan, timestep, q₀, p₀; v̄=v̄, parameters=parameters)
+    end
 end
 
 function lodeproblem(q₀, p₀; kwargs...)
     @assert length(q₀) == length(p₀)
-    lodeproblem(length(q₀), q₀, p₀; kwargs...)
+    lodeproblem(_length(q₀), q₀, p₀; kwargs...)
 end
 
-function lodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
-    leqs = functions(lagrangian_system(N, _parameters(parameters)))
-    heqs = functions(hamiltonian_system(N, _parameters(parameters)))
-    LODEEnsemble(leqs.ϑ, leqs.f, leqs.g, leqs.ω, leqs.L, timespan, timestep, q₀, p₀; parameters=parameters, v̄=heqs.v)
+"""
+    lodeensemble(N, q₀, p₀; timespan, timestep, parameters, symbolic)
+
+Lagrangian ensemble for the Toda lattice (varying initial conditions and/or parameters).
+
+Takes the same arguments as [`lodeproblem`](@ref), with `q₀`, `p₀` and/or `parameters` given as
+vectors of samples.
+"""
+function lodeensemble(N::Int=Ñ, q₀=compute_initial_q(μ, N), p₀=zero(q₀);
+                      timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP,
+                      parameters=default_parameters(), symbolic=false)
+    _check_size(N, q₀, p₀)
+    if symbolic
+        leqs = functions(lagrangian_system(N, _parameters(parameters)))
+        LODEEnsemble(leqs.ϑ, leqs.f, leqs.g, leqs.ω, leqs.L, timespan, timestep, q₀, p₀;
+                     v̄=v̄, parameters=parameters)
+    else
+        LODEEnsemble(toda_lattice_ϑ, toda_lattice_f, toda_lattice_g, ω!, lagrangian,
+                     timespan, timestep, q₀, p₀; v̄=v̄, parameters=parameters)
+    end
 end
 
 function lodeensemble(q₀, p₀; kwargs...)

--- a/test/lode_wiring_tests.jl
+++ b/test/lode_wiring_tests.jl
@@ -13,6 +13,7 @@ import GeometricProblems.MasslessChargedParticle as mcp
 import GeometricProblems.MasslessChargedParticleSingular as mcps
 import GeometricProblems.PointVortices as pv
 import GeometricProblems.PointVorticesLinear as pvl
+import GeometricProblems.TodaLattice as toda
 
 # `LODEProblem(ϑ, f, g, ω, l, …)` and `LDAEProblem(…, ϕ, ū, ḡ, ψ, ω, l, …)` take the symplectic
 # matrix `ω` and the Lagrangian `l` as *adjacent positional* arguments. No integrator in
@@ -51,6 +52,13 @@ const WAVE_N = 5
 const wave_q = lw.compute_initial_condition2(lw.μ̃, WAVE_N + 2).q
 const wave_v = lw.compute_initial_condition2(lw.μ̃, WAVE_N + 2).p
 
+# `TodaLattice` is entered on a small lattice for the same reason, and its state has exactly N
+# components, so N = 5 gives d = 5 and a 10×10 two-form. Its default initial momentum is zero, which
+# would make `l` degenerate here, so the velocity is offset.
+const TODA_N = 5
+const toda_q = toda.compute_initial_q(toda.μ, TODA_N)
+const toda_v = zero(toda_q) .+ 0.1
+
 const LODE_PROBLEMS = (
     ("HarmonicOscillator.lodeproblem",              ho.lodeproblem(),               1, true,  ([0.7], [0.3])),
     ("HarmonicOscillator.ldaeproblem",              ho.ldaeproblem(),               1, true,  ([0.7], [0.3])),
@@ -71,6 +79,7 @@ const LODE_PROBLEMS = (
     ("MasslessChargedParticleSingular.ldaeproblem", mcps.ldaeproblem(),             2, false, ([1.3, 0.2], [0.7, -0.4])),
     ("PointVortices.lodeproblem_formal_lagrangian", pv.lodeproblem_formal_lagrangian(),  4, false, ([0.2, 0.4, 0.4, 0.2], [0.1, -0.1, 0.2, 0.3])),
     ("PointVorticesLinear.lodeproblem_formal_lagrangian", pvl.lodeproblem_formal_lagrangian(), 4, false, ([0.3, 0.0, -0.6, 0.1], [0.1, -0.1, 0.2, 0.3])),
+    ("TodaLattice.lodeproblem",                     toda.lodeproblem(TODA_N),       TODA_N, true,  (toda_q, toda_v)),
 )
 
 @testset "$(rpad("LODE/LDAE ω and l wiring",80))" begin

--- a/test/toda_lattice_tests.jl
+++ b/test/toda_lattice_tests.jl
@@ -1,6 +1,10 @@
-using GeometricIntegrators: Gauss, integrate, relative_maximum_error
+using GeometricEquations: HODEEnsemble, HODEProblem, LODEEnsemble, LODEProblem, functions, initialguess
+using GeometricIntegrators: Gauss, ImplicitMidpoint, integrate, relative_maximum_error
 using GeometricProblems.TodaLattice
+using LinearAlgebra
 using Test
+
+const TL = TodaLattice
 
 
 # Parameters and initial conditions
@@ -73,4 +77,208 @@ lode_sol = integrate(lode_ens, Gauss(1))
 
 for (hsol,lsol) in zip(hode_sol,lode_sol)
     @test relative_maximum_error(hsol.q, lsol.q) < 2E-14
+end
+
+
+# The two default-size constructions below used to generate the equations of motion symbolically for
+# Ñ = 200; `lodeproblem` alone cost minutes there, most of it spent on a dense 400×400 two-form that
+# no integrator ever evaluates. They are now instantaneous, and the identity assertions are what keep
+# them that way: if the default ever routes through EulerLagrange again, these fail rather than
+# merely getting slow.
+
+@testset "$(rpad("Toda Lattice: default constructors are hand-written",80))" begin
+    hode = @test_nowarn hodeproblem()
+    lode = @test_nowarn lodeproblem()
+
+    @test hode isa HODEProblem
+    @test lode isa LODEProblem
+
+    @test functions(hode).v === TL.toda_lattice_v
+    @test functions(hode).f === TL.toda_lattice_f
+    @test functions(hode).h === TL.hamiltonian
+
+    @test functions(lode).ϑ === TL.toda_lattice_ϑ
+    @test functions(lode).f === TL.toda_lattice_f
+    @test functions(lode).g === TL.toda_lattice_g
+    @test functions(lode).ω === TL.ω!
+    @test functions(lode).l === TL.lagrangian
+
+    # was `functions(hamiltonian_system(N, …)).v`, for which an entire second `HamiltonianSystem`
+    # had to be built although the function it yields is just `v .= p`
+    @test initialguess(lode).v === TL.v̄
+end
+
+@testset "$(rpad("Toda Lattice: hand-written matches generated",80))" begin
+    # Small on purpose: `lagrangian_system` grows as N^2.4 and the generated `ω` as N^2.
+    M = 5
+
+    q = TL.compute_initial_q(μ, M) .+ 0.05 .* collect(1 : M)
+    p = collect(range(0.1, 0.4, length = M))
+    v = copy(p)                 # the mass matrix is the identity, so q̇ = p
+
+    hamiltonian_functions = functions(TL.hamiltonian_system(M, params))
+    lagrangian_functions = functions(TL.lagrangian_system(M, params))
+
+    generated = zeros(M)
+    handwritten = zeros(M)
+
+    # ∂H/∂p = p
+    hamiltonian_functions.v(generated, 0.0, q, p, params)
+    TL.toda_lattice_v(handwritten, 0.0, q, p, params)
+    @test generated ≈ handwritten
+    @test handwritten == p
+
+    # -∂H/∂q, and the identical ∂L/∂q
+    hamiltonian_functions.f(generated, 0.0, q, p, params)
+    TL.toda_lattice_f(handwritten, 0.0, q, p, params)
+    @test generated ≈ handwritten
+    @test any(!iszero, handwritten)
+
+    lagrangian_functions.f(generated, 0.0, q, v, params)
+    TL.toda_lattice_f(handwritten, 0.0, q, v, params)
+    @test generated ≈ handwritten
+
+    # ϑ = ∂L/∂q̇ = q̇
+    lagrangian_functions.ϑ(generated, 0.0, q, v, params)
+    TL.toda_lattice_ϑ(handwritten, 0.0, q, v, params)
+    @test generated ≈ handwritten
+    @test any(!iszero, handwritten)
+
+    # g = λ, in both arities
+    λ = collect(range(0.1, 0.7, length = M))
+    lagrangian_functions.g(generated, 0.0, q, v, λ, params)
+    TL.toda_lattice_g(handwritten, 0.0, q, v, λ, params)
+    @test generated ≈ handwritten ≈ λ
+    TL.toda_lattice_g(handwritten, 0.0, q, λ, params)
+    @test handwritten ≈ λ
+
+    @test lagrangian_functions.L(0.0, q, v, params) ≈ lagrangian(0.0, q, v, params, M)
+    @test hamiltonian_functions.H(0.0, q, p, params) ≈ hamiltonian(0.0, q, p, params, M)
+
+    # the four-argument methods GeometricEquations requires recover N = length(q)
+    @test lagrangian(0.0, q, v, params) == lagrangian(0.0, q, v, params, M)
+    @test hamiltonian(0.0, q, p, params) == hamiltonian(0.0, q, p, params, M)
+
+    # `∇V!` is where the hand-written formulation could go wrong: the lattice is periodic, so the
+    # gradient α (Eⱼ - Eⱼ₋₁) wraps around at j = 1, and that wrap-around is checked by nothing else.
+    # Differentiate `potential` itself, which shares no code with `∇V!`. N = 1 and N = 2 are included
+    # because they are the cases where the wrap-around collapses: at N = 1 the neighbour of the only
+    # point is itself, and at N = 2 the forward and backward neighbours coincide.
+    function reference_∇V!(dV, q, params, N)
+        h = 1e-6
+        for i in eachindex(q)
+            qp = copy(q); qp[i] += h
+            qm = copy(q); qm[i] -= h
+            dV[i] = (TL.potential(qp, params, N) - TL.potential(qm, params, N)) / 2h
+        end
+        nothing
+    end
+
+    for K in (1, 2, 3, 5, 12, 64)
+        # perturbed off the initial condition, so that no entry is accidentally zero
+        qK = TL.compute_initial_q(μ, K) .+ 0.1 .* collect(1:K)
+        kernel = zeros(K)
+        reference = zeros(K)
+        TL.∇V!(kernel, qK, params, K)
+        reference_∇V!(reference, qK, params, K)
+        @test kernel ≈ reference rtol = 1e-6 atol = 1e-8
+        # At K = 1 the only neighbour of the only point is itself, so V is constant and ∇V vanishes
+        # identically — the one size at which an all-zero gradient is the right answer.
+        K == 1 ? (@test all(iszero, kernel)) : (@test any(!iszero, kernel))
+
+        # `scale` scales the gradient; scale = -1 is what the force function uses
+        negated = zeros(K)
+        TL.∇V!(negated, qK, params, K, -1)
+        @test negated ≈ -kernel
+
+        # Every entry of the output is written once and none is read back, and the wrap-around term
+        # is evaluated before the first write, so the kernel is correct even when the output aliases
+        # the state. Nothing in the package calls it that way; the assertion is here because the
+        # single-pass formulation is what makes it true, and a return to a scratch-space version
+        # would silently break it.
+        aliased = copy(qK)
+        TL.∇V!(aliased, aliased, params, K)
+        @test aliased ≈ kernel
+    end
+
+    # The Lagrangian is regular (ϑ = q̇, M = I), so the two-form is the 2N×2N canonical [0 -I; I 0].
+    Ω = ones(2M, 2M)
+    TL.ω!(Ω, 0.0, q, v, params)
+    @test Ω ≈ [zeros(M, M) -I(M); I(M) zeros(M, M)]
+    @test Ω ≈ -transpose(Ω)
+    @test count(!iszero, Ω) == 2M
+
+    # ...and it agrees with what EulerLagrange generates.
+    generated_ω = zeros(2M, 2M)
+    lagrangian_functions.ω(generated_ω, 0.0, q, v, params)
+    @test generated_ω ≈ Ω
+end
+
+@testset "$(rpad("Toda Lattice: integration agreement",80))" begin
+    M = 5
+    timespan = (0.0, 0.5)
+    timestep = 0.005
+
+    qM = TL.compute_initial_q(μ, M)
+    pM = zero(qM)
+
+    hode = hodeproblem(M, qM, pM; timespan = timespan, timestep = timestep)
+    lode = lodeproblem(M, qM, pM; timespan = timespan, timestep = timestep)
+
+    hode_sol = integrate(hode, ImplicitMidpoint())
+    lode_sol = integrate(lode, ImplicitMidpoint())
+
+    @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1E-12
+    @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1E-11
+
+    # The hand-written vector fields exist precisely to replace the generated ones, so they have to
+    # keep agreeing with them.
+    hode_sym = hodeproblem(M, qM, pM; timespan = timespan, timestep = timestep, symbolic = true)
+    lode_sym = lodeproblem(M, qM, pM; timespan = timespan, timestep = timestep, symbolic = true)
+
+    hode_sym_sol = integrate(hode_sym, ImplicitMidpoint())
+    lode_sym_sol = integrate(lode_sym, ImplicitMidpoint())
+
+    @test relative_maximum_error(hode_sol.q, hode_sym_sol.q) < 1E-12
+    @test relative_maximum_error(hode_sol.p, hode_sym_sol.p) < 1E-11
+    @test relative_maximum_error(lode_sol.q, lode_sym_sol.q) < 1E-12
+    @test relative_maximum_error(lode_sol.p, lode_sym_sol.p) < 1E-11
+
+    # The `symbolic = true` LODE keeps the hand-written `v̄` too — that is the whole point of no
+    # longer building a second `HamiltonianSystem` for it.
+    @test initialguess(lode_sym).v === TL.v̄
+
+    # The two-argument form infers N from the state, in both branches.
+    @test hodeproblem(qM, pM) isa HODEProblem
+    @test lodeproblem(qM, pM) isa LODEProblem
+    @test lodeproblem(qM, pM; symbolic = true) isa LODEProblem
+
+    # ...and it does so through `_length`, so a vector of samples gives the size of one sample rather
+    # than the number of samples.
+    @test hodeensemble([qM, qM .+ 0.1], [pM, pM]) isa HODEEnsemble
+    @test lodeensemble([qM, qM .+ 0.1], [pM, pM]) isa LODEEnsemble
+
+    # The hand-written fields read the size off the state while the symbolic ones bake it in, so an
+    # `N` that disagrees with the initial condition has to be rejected rather than silently meaning
+    # two different systems depending on `symbolic`.
+    @test_throws AssertionError hodeproblem(M + 1, qM, pM)
+    @test_throws AssertionError lodeproblem(M + 1, qM, pM)
+end
+
+# The ensembles above are hand-written now, so the symbolic branch of `hodeensemble`/`lodeensemble` —
+# which destructures `functions(...)`, a different code path from the problem constructors — is only
+# covered if it is asked for explicitly. `test/eulerlagrange_ensembles_tests.jl` exists to exercise
+# the EulerLagrange ensemble plumbing and names this file as its `TodaLattice` counterpart, so the
+# coverage has to stay here. Small lattice, as there: construction is all this checks, and
+# `lagrangian_system` grows as N^2.4.
+@testset "$(rpad("Toda Lattice: symbolic ensembles (construction)",80))" begin
+    M = 5
+    qM = TL.compute_initial_q(μ, M)
+    pM = zero(qM)
+    pv = [params, NamedTuple{keys(params)}(values(params) .+ 0.1)]
+
+    @test hodeensemble(M; parameters = pv, symbolic = true) isa HODEEnsemble
+    @test lodeensemble(M; parameters = pv, symbolic = true) isa LODEEnsemble
+    @test hodeensemble([qM, qM .+ 0.01], [pM, pM]; symbolic = true) isa HODEEnsemble
+    @test lodeensemble([qM, qM .+ 0.01], [pM, pM]; symbolic = true) isa LODEEnsemble
 end


### PR DESCRIPTION
Closes the `TodaLattice` item under *Known follow-ups* in `CHANGELOG.md`, the last of the three symbolic-construction conversions (after `OuterSolarSystem` and `LinearWave`).

## The problem

`TodaLattice` was the only problem left generating its equations of motion symbolically by default. Two costs, both recorded in the follow-up:

1. **The dense `ω`.** EulerLagrange builds the `2N × 2N` Lagrange two-form by symbolically differentiating a dense matrix — 160 k entries at the default `Ñ = 200`. `lagrangian_system(200, …)` takes **73 s** and emits **8.4 MB** of code whose first `ω` evaluation costs a further **82 s**. The true value is the canonical `[0 -I; I 0]`: 400 nonzeros out of 160 000, for a two-form no integrator in GeometricIntegrators evaluates and that `check_methods` skips.
2. **The redundant `HamiltonianSystem`.** `lodeproblem` and `lodeensemble` built a second, complete symbolic system solely to obtain `v̄ = heqs.v`. Since `H = p⋅p/2 + V(q)`, that function is `v .= p`. This was the last such call site in the package.

## The change

The four constructors now use hand-written in-place `v`, `f`, `ϑ`, `g` and `ω!` over a shared `∇V!` kernel. `symbolic = true` still routes them through `hamiltonian_system`/`lagrangian_system` for cross-checking.

| | before | after |
|---|---|---|
| `lodeproblem()` at `N = 200` | 73 s + 82 s first `ω` call | **20 µs** |
| `hodeproblem()` at `N = 200` | 1.2 s | **7 µs** |

The lattice is periodic, so with `Eₙ = exp(qₙ - qₙ₊₁)` the gradient is `∂V/∂qⱼ = α (Eⱼ - Eⱼ₋₁)` with `E₀ ≡ E_N`. `∇V!` computes the wrap-around term `E_N` — which is also `E₀` — once, before it writes anything, then makes a **single pass** carrying `Eⱼ₋₁` in a scalar and writing each output as it goes: no allocation, one `exp` per site, which is the whole cost, and one entry, the last, peeled off. It is correct for every `N ≥ 1`.

Because no entry of the output is ever read back and `E_N` is taken before the first write, the kernel is also correct when its output *aliases* the state. Nothing in the package calls it that way; the property is asserted because it is exactly what the single pass buys, and a return to a scratch-space formulation would silently lose it.

## One result worth flagging

Unlike the linear wave, **the per-call comparison does not favour the hand-written code everywhere**. Both force functions are dominated by the `N` exponentials rather than by arithmetic, so the generated force stays ahead — by 10% at `N = 8`, 12% at `N = 32`, 8% at `N = 128` and 5% at `N = 200` — while the hand-written `H` and `L` are 1.3–2× faster and `v`, `ϑ`, `g` change places with size. Writing `∇V!` as a single pass rather than filling the output with the `Eₙ` and overwriting them buys a further 3–4% at every size, which narrows that gap without closing it.

There is therefore a real break-even here rather than none at all — it is just never reached: the 155 s of setup a `symbolic = true` LODE pays at `N = 200` takes **6.9 × 10⁹** force evaluations to earn back, some six orders of magnitude beyond a default run. The module docstring and changelog say this plainly rather than claiming a clean sweep.

## Latent defects fixed in passing

- The two-argument `hodeproblem(q₀, p₀)`/`lodeproblem(q₀, p₀)` forms sized themselves with `length(q₀)` where the ensemble forms correctly used `_length(q₀)` — handed a vector of samples they took the *number of samples* for the lattice size.
- `lodeproblem`/`hodeproblem` passed `parameters` raw to one symbolic builder and `_parameters(parameters)` to the other, so a vector of parameter sets reached `symbolize` asymmetrically.
- `hamiltonian`/`lagrangian` lacked the four-argument methods GeometricEquations requires of a problem's `H` and `l` (see `check_methods`).
- Removed the unused module-level `const Ω` — a plot domain nothing referenced, which would have read as the two-form next to the new `ω!`.
- `docs/src/toda_lattice.md` gained the `@autodocs` block the other converted problem pages have. The module docstring is rendered there, via `@docs`, and now carries `@ref` links; an unresolved `@ref` is a fatal `:cross_references` error, so without the block the docs build terminated before rendering — and the new `potential`, `∇V!`, `ω!` and constructor docstrings went unrendered besides.
- `hamiltonian_system`/`lagrangian_system` gained the `(N::Int, parameters::NamedTuple)` annotations `linear_wave.jl` gives them, and `_parameters` accepts any `AbstractVector`, as it does there.

## Tests

`test/toda_lattice_tests.jl`: **16 assertions → 88**. Four testsets added, mirroring `linear_wave_tests.jl`:

- function identity on the default-size constructions (`functions(prob).f === TodaLattice.toda_lattice_f` and friends, plus `initialguess(lode).v === TodaLattice.v̄`) — the cheapest possible guard that the default never routes through EulerLagrange again;
- a cross-check at `N = 5` of every generated function against its hand-written counterpart, including the `2N × 2N` `ω`;
- integration agreement against `symbolic = true` under `ImplicitMidpoint`;
- symbolic ensemble construction, so that `test/eulerlagrange_ensembles_tests.jl` — which names this file as its `TodaLattice` counterpart — does not silently lose that coverage, the same trap the linear wave hit.

`∇V!` is checked against a central finite difference of `potential`, which shares no code with it, at `N = 1, 2, 3, 5, 12, 64`, and at each of those sizes with its output aliased onto the state. The periodic wrap-around is verified by nothing else, and `N = 1` and `N = 2` are the sizes at which it collapses — at `N = 1` the only neighbour of the only point is itself, so the gradient vanishes identically and the test asserts exactly that.

`TodaLattice.lodeproblem` is now registered in `test/lode_wiring_tests.jl` (100 assertions, up from 95); that file asks for every new `lodeproblem` to be listed and had never covered it.

Full `Pkg.test()` passes, as does the pre-push hook suite. The live `@example` in `docs/src/toda_lattice.md` renders correctly.

`benchmark/toda_lattice.jl` is added in the shape of `benchmark/linear_wave.jl` and backs every number above; `TODA_LATTICE_BENCH_FULL=1` waives the per-size budget and sweeps to `Ñ = 200`. Its break-even section now says when its per-call figures come from a smaller lattice than its setup figure, and which way that biases the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
