### PR TITLE
Normalize all source files to NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ Categories: **Bug fixes** = code defects (typos, wrong API calls, crashes, bad i
 > Development notes for the 0.7.0 correctness audit — the original findings report, its
 > remediation plan and the execution log — are archived under [`docs/dev/`](docs/dev/).
 
+## [Unreleased]
+
+### Repository hygiene
+- **Every source file is now NFC-normalized**, and `test/unicode_normalization_tests.jl` keeps it that
+  way. Accented identifiers had drifted into both legal spellings: `ū` as U+016B in some files and as
+  `u` + U+0304 COMBINING MACRON in others, likewise `ḡ`, `ṗ`, `ñ` and the `é` of *Hénon* in
+  `README.md` and `docs/make.jl`. Julia's parser NFC-normalizes identifiers, so the two spellings are
+  the same binding and no test of behaviour could ever tell them apart — but they are not the same
+  text. `grep ū` typed one way silently finds nothing while the identifier sits plainly on screen, and
+  an exact-string edit fails for no visible reason. Files drift between the forms without anyone
+  touching a character, since macOS filesystem APIs hand back decomposed text and some editors
+  recompose on save.
+
+  Seven files changed, 31 lines in all, folding away 44 combining marks — every line canonically
+  equivalent to the one it replaces: `src/harmonic_oscillator.jl`, `src/lotka_volterra_2d_common.jl`,
+  `src/lotka_volterra_2d_equations.jl`, `src/lotka_volterra_2d_symmetric.jl`,
+  `src/lotka_volterra_4d.jl`, `README.md`, `docs/make.jl`. `src/toda_lattice.jl` was the eighth until
+  0.8.0's hand-written Toda vector fields rewrote its `Ñ` lines into NFC as a side effect, which is
+  what leaves `Ñ` off the list above.
+
+  The test asserts the normal form of each file rather than any particular character, so there is no
+  list of accented identifiers to maintain, and characters with no precomposed form pass untouched —
+  `q̇` is `q` + U+0307 and has no single codepoint, so it is already in normal form. `obsolete/` is
+  excluded, being kept for reference and not edited.
+
+  `Unicode` is now a declared dependency in `test/Project.toml`, for the third time the same reason
+  applies after `Logging` and `LinearAlgebra`: an undeclared stdlib resolves under
+  `julia --project=test` but not inside the sandbox `Pkg.test` builds from that file, where it fails
+  with *"Package Unicode not found in current path"*. `test/Project.toml`.
+
 ## [0.8.0] — 2026-07-30
 
 ### Model fixes

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [x] ABC Flow,
 - [x] Exponential Growth,
 - [ ] Fermi-Pasta-Ulam Problem,
-- [ ] Hénon-Heiles System,
+- [ ] Hénon-Heiles System,
 - [ ] Kepler Problem,
 - [x] Lorenz Attractor in 3D,
 - [x] Lotka-Volterra in 2D,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,7 @@ makedocs(;
              "Double Pendulum"             => "double_pendulum.md",
              "Harmonic Oscillator"         => "harmonic_oscillator.md",
              "Kubo Oscillator"             => "kubo_oscillator.md",
-             "Hénon-Heiles System"         => "henon_heiles.md",
+             "Hénon-Heiles System"         => "henon_heiles.md",
              "Kepler Problem"              => "kepler_problem.md",
              "Linear Wave Equation"        => "linear_wave.md",
              "Lorenz Attractor"            => "lorenz_attractor.md",

--- a/src/harmonic_oscillator.jl
+++ b/src/harmonic_oscillator.jl
@@ -459,22 +459,22 @@ function oscillator_pdae_g(g, t, q, p, λ, params)
     nothing
 end
 
-function oscillator_pdae_ū(u, t, q, p, λ, params)
+function oscillator_pdae_ū(u, t, q, p, λ, params)
     @unpack k = params
     u[1] = k * q[1] * λ[1]
     nothing
 end
 
-function oscillator_pdae_ḡ(g, t, q, p, λ, params)
+function oscillator_pdae_ḡ(g, t, q, p, λ, params)
     g[1] = p[1] * λ[1] / params.m
     nothing
 end
 
 # The energy constraint is built per problem, see `_pdae_energy_constraint`.
 
-function oscillator_pdae_ψ(ψ, t, q, p, q̇, ṗ, params)
+function oscillator_pdae_ψ(ψ, t, q, p, q̇, ṗ, params)
     @unpack k = params
-    ψ[1] = p[1] * ṗ[1] / params.m + k * q[1] * q̇[1]
+    ψ[1] = p[1] * ṗ[1] / params.m + k * q[1] * q̇[1]
     nothing
 end
 
@@ -491,18 +491,18 @@ function hdaeproblem(q₀=q₀, p₀=p₀, λ₀=zero(q₀); timespan=DEFAULT_TI
     constraint = _pdae_energy_constraint(hamiltonian(timespan[begin], q₀, p₀, parameters))
     HDAEProblem(oscillator_pdae_v, oscillator_pdae_f,
         oscillator_pdae_u, oscillator_pdae_g, constraint,
-        oscillator_pdae_ū, oscillator_pdae_ḡ, oscillator_pdae_ψ,
+        oscillator_pdae_ū, oscillator_pdae_ḡ, oscillator_pdae_ψ,
         hamiltonian, timespan, timestep, q₀, p₀, λ₀; parameters=parameters)
 end
 
 
 oscillator_idae_u(u, t, q, v, p, λ, params) = oscillator_pdae_u(u, t, q, p, λ, params)
 oscillator_idae_g(g, t, q, v, p, λ, params) = oscillator_pdae_g(g, t, q, p, λ, params)
-oscillator_idae_ū(u, t, q, v, p, λ, params) = oscillator_pdae_ū(u, t, q, p, λ, params)
-oscillator_idae_ḡ(g, t, q, v, p, λ, params) = oscillator_pdae_ḡ(g, t, q, p, λ, params)
+oscillator_idae_ū(u, t, q, v, p, λ, params) = oscillator_pdae_ū(u, t, q, p, λ, params)
+oscillator_idae_ḡ(g, t, q, v, p, λ, params) = oscillator_pdae_ḡ(g, t, q, p, λ, params)
 # The energy constraint of the implicit/variational forms is the same closure as for the
 # partitioned ones; it already accepts the extra velocity slot.
-oscillator_idae_ψ(ψ, t, q, v, p, q̇, ṗ, params) = oscillator_pdae_ψ(ψ, t, q, p, q̇, ṗ, params)
+oscillator_idae_ψ(ψ, t, q, v, p, q̇, ṗ, params) = oscillator_pdae_ψ(ψ, t, q, p, q̇, ṗ, params)
 
 function idaeproblem(q₀=q₀, p₀=p₀, λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
     @assert length(q₀) == length(p₀) == length(λ₀) == 1

--- a/src/lotka_volterra_2d_common.jl
+++ b/src/lotka_volterra_2d_common.jl
@@ -155,14 +155,14 @@ end
 lotka_volterra_2d_g(g, t, q, p, λ, params) = lotka_volterra_2d_g(g, t, q, λ, params)
 lotka_volterra_2d_g(g, t, q, v, p, λ, params) = lotka_volterra_2d_g(g, t, q, p, λ, params)
 
-function lotka_volterra_2d_ḡ(g::AbstractVector, t, q::AbstractVector, v::AbstractVector, params)
+function lotka_volterra_2d_ḡ(g::AbstractVector, t, q::AbstractVector, v::AbstractVector, params)
     g[1] = g₁(t, q, v)
     g[2] = g₂(t, q, v)
     nothing
 end
 
-lotka_volterra_2d_ḡ(g, t, q, p, λ, params) = lotka_volterra_2d_ḡ(g, t, q, λ, params)
-lotka_volterra_2d_ḡ(g, t, q, v, p, λ, params) = lotka_volterra_2d_ḡ(g, t, q, p, λ, params)
+lotka_volterra_2d_ḡ(g, t, q, p, λ, params) = lotka_volterra_2d_ḡ(g, t, q, λ, params)
+lotka_volterra_2d_ḡ(g, t, q, v, p, λ, params) = lotka_volterra_2d_ḡ(g, t, q, p, λ, params)
 
 function lotka_volterra_2d_u_dae(u, t, q, λ, params)
     u[1] = 0
@@ -180,13 +180,13 @@ end
 lotka_volterra_2d_u(u, t, q, p, λ, params) = lotka_volterra_2d_u(u, t, q, λ, params)
 lotka_volterra_2d_u(u, t, q, v, p, λ, params) = lotka_volterra_2d_u(u, t, q, p, λ, params)
 
-function lotka_volterra_2d_ū(u, t, q, λ, params)
+function lotka_volterra_2d_ū(u, t, q, λ, params)
     u .= λ
     nothing
 end
 
-lotka_volterra_2d_ū(u, t, q, p, λ, params) = lotka_volterra_2d_ū(u, t, q, λ, params)
-lotka_volterra_2d_ū(u, t, q, v, p, λ, params) = lotka_volterra_2d_ū(u, t, q, p, λ, params)
+lotka_volterra_2d_ū(u, t, q, p, λ, params) = lotka_volterra_2d_ū(u, t, q, λ, params)
+lotka_volterra_2d_ū(u, t, q, v, p, λ, params) = lotka_volterra_2d_ū(u, t, q, p, λ, params)
 
 function lotka_volterra_2d_ϕ_dae(ϕ, t, q, params)
     ϕ[1] = q[3] - v₁(t, q, params)
@@ -202,15 +202,15 @@ end
 
 lotka_volterra_2d_ϕ(ϕ, t, q, v, p, params) = lotka_volterra_2d_ϕ(ϕ, t, q, p, params)
 
-function lotka_volterra_2d_ψ(ψ, t, q, p, q̇, ṗ, params)
-    ψ[1] = ṗ[1] - g₁(t, q, q̇)
-    ψ[2] = ṗ[2] - g₂(t, q, q̇)
+function lotka_volterra_2d_ψ(ψ, t, q, p, q̇, ṗ, params)
+    ψ[1] = ṗ[1] - g₁(t, q, q̇)
+    ψ[2] = ṗ[2] - g₂(t, q, q̇)
     nothing
 end
 
-lotka_volterra_2d_ψ(ψ, t, q, v, p, q̇, ṗ, params) = lotka_volterra_2d_ψ(ψ, t, q, p, q̇, ṗ, params)
+lotka_volterra_2d_ψ(ψ, t, q, v, p, q̇, ṗ, params) = lotka_volterra_2d_ψ(ψ, t, q, p, q̇, ṗ, params)
 
-function lotka_volterra_2d_ψ_lode(ψ, t, q, v, p, q̇, ṗ, params)
+function lotka_volterra_2d_ψ_lode(ψ, t, q, v, p, q̇, ṗ, params)
     ψ[1] = f₁(t, q, v) - g₁(t, q, v) - dHd₁(t, q, params)
     ψ[2] = f₂(t, q, v) - g₂(t, q, v) - dHd₂(t, q, params)
     nothing

--- a/src/lotka_volterra_2d_equations.jl
+++ b/src/lotka_volterra_2d_equations.jl
@@ -101,7 +101,7 @@ end
 function hdaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
     HDAEProblem(lotka_volterra_2d_v, lotka_volterra_2d_f,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
-                lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ,
+                lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ,
                 hamiltonian, timespan, timestep, q₀, p₀, λ₀; parameters=parameters)
 end
 
@@ -133,7 +133,7 @@ end
 function ldaeproblem(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
     LDAEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f_ham,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
-                lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ_lode,
+                lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ_lode,
                 lotka_volterra_2d_ω, lagrangian,
                 timespan, timestep, q₀, p₀, λ₀; parameters=parameters, invariants=(h=hamiltonian,),
                 v̄=lotka_volterra_2d_v, f̄=lotka_volterra_2d_f)
@@ -143,7 +143,7 @@ end
 function ldaeproblem_slrk(q₀=q₀, p₀=ϑ(t₀, q₀), λ₀=zero(q₀); timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())
     LDAEProblem(lotka_volterra_2d_ϑ, lotka_volterra_2d_f,
                 lotka_volterra_2d_u, lotka_volterra_2d_g, lotka_volterra_2d_ϕ,
-                lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ,
+                lotka_volterra_2d_ū, lotka_volterra_2d_ḡ, lotka_volterra_2d_ψ,
                 lotka_volterra_2d_ω, lagrangian,
                 timespan, timestep, q₀, p₀, λ₀; parameters=parameters, invariants=(h=hamiltonian,),
                 v̄=lotka_volterra_2d_v, f̄=lotka_volterra_2d_f)

--- a/src/lotka_volterra_2d_symmetric.jl
+++ b/src/lotka_volterra_2d_symmetric.jl
@@ -8,7 +8,7 @@ H(q) &= a_1 \, q_1 + a_2 \, q_2 + b_1 \, \log q_1 + b_2 \, \log q_2
 \end{aligned}
 ```
 
-This Lagrangian is a slight generalization of Equation (5) in José Fernández-Núñez,
+This Lagrangian is a slight generalization of Equation (5) in José Fernández-Núñez,
 Lagrangian Structure of the Two-Dimensional Lotka-Volterra System, International
 Journal of Theoretical Physics, Vol. 37, No. 9, pp. 2457-2462, 1998.
 

--- a/src/lotka_volterra_4d.jl
+++ b/src/lotka_volterra_4d.jl
@@ -363,15 +363,15 @@ end
 
 lotka_volterra_4d_ϕ(ϕ, t, q, v, p, params) = lotka_volterra_4d_ϕ(ϕ, t, q, p, params)
 
-function lotka_volterra_4d_ψ(ψ, t, q, p, q̇, ṗ, params)
-    ψ[1] = ṗ[1] - g₁(t, q, q̇)
-    ψ[2] = ṗ[2] - g₂(t, q, q̇)
-    ψ[3] = ṗ[3] - g₃(t, q, q̇)
-    ψ[4] = ṗ[4] - g₄(t, q, q̇)
+function lotka_volterra_4d_ψ(ψ, t, q, p, q̇, ṗ, params)
+    ψ[1] = ṗ[1] - g₁(t, q, q̇)
+    ψ[2] = ṗ[2] - g₂(t, q, q̇)
+    ψ[3] = ṗ[3] - g₃(t, q, q̇)
+    ψ[4] = ṗ[4] - g₄(t, q, q̇)
     nothing
 end
 
-lotka_volterra_4d_ψ(ψ, t, q, v, p, q̇, ṗ, params) = lotka_volterra_4d_ψ(ψ, t, q, p, q̇, ṗ, params)
+lotka_volterra_4d_ψ(ψ, t, q, v, p, q̇, ṗ, params) = lotka_volterra_4d_ψ(ψ, t, q, p, q̇, ṗ, params)
 
 
 function odeproblem(q₀=q₀; timespan=DEFAULT_TIMESPAN, timestep=DEFAULT_TIMESTEP, parameters=default_parameters())

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [sources]
 GeometricProblems = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using SafeTestsets
 
+@safetestset "Unicode normalization (NFC)                                                     " begin
+    include("unicode_normalization_tests.jl")
+end
 @safetestset "Default timespan/timestep constants                                             " begin
     include("default_timespan_timestep_tests.jl")
 end

--- a/test/unicode_normalization_tests.jl
+++ b/test/unicode_normalization_tests.jl
@@ -1,0 +1,50 @@
+using Test
+using Unicode: normalize
+
+# Every source file in this repository is NFC-normalized.
+#
+# Accented identifiers have two legal spellings: `ū` as the single codepoint U+016B, or `u` followed
+# by U+0304 COMBINING MACRON. Julia's parser NFC-normalizes identifiers, so the two are the *same
+# binding* — a file mixing them compiles and runs identically, and no test of behaviour can tell them
+# apart. What they are not is the same *text*: `grep ū` typed one way silently finds nothing while the
+# identifier sits plainly on screen, and an exact-string edit fails for no visible reason. Files drift
+# between the forms without anyone touching a character, because macOS filesystem APIs hand back
+# decomposed text and some editors recompose on save.
+#
+# This asserts the normal form of the file rather than any particular character, so there is no list
+# of accented identifiers to keep up to date. Characters with no precomposed form pass untouched:
+# `q̇` is `q` followed by U+0307 and there is no single codepoint for it, so it is already in normal
+# form. `obsolete/` is excluded — it is kept for reference and not edited.
+
+const REPO_ROOT = dirname(@__DIR__)
+const SKIP_DIRS = ("obsolete", "build", "node_modules")
+const EXTENSIONS = (".jl", ".md", ".toml", ".yml", ".bib")
+
+"Every text file in the repository whose normal form this test is responsible for."
+function source_files(root = REPO_ROOT)
+    files = String[]
+    for (dir, subdirs, names) in walkdir(root)
+        # prune rather than filter afterwards, so that `.git` and friends are never descended into
+        filter!(d -> d ∉ SKIP_DIRS && !startswith(d, "."), subdirs)
+        for name in names
+            any(ext -> endswith(name, ext), EXTENSIONS) && push!(files, joinpath(dir, name))
+        end
+    end
+    return sort!(files)
+end
+
+@testset "$(rpad("Unicode normalization (NFC)", 80))" begin
+    files = source_files()
+
+    # A walk that found nothing would make the assertion below pass vacuously.
+    @test !isempty(files)
+
+    offenders = String[]
+    for file in files
+        text = read(file, String)
+        normalize(text, :NFC) == text || push!(offenders, relpath(file, REPO_ROOT))
+    end
+
+    # Named rather than counted, so that a failure says which file to run `normalize` over.
+    @test offenders == String[]
+end


### PR DESCRIPTION
Follow-up to the review of #110, which turned up an encoding inconsistency that had been in the tree for a long time.

## The problem

Accented identifiers in this repository had drifted into both of their legal spellings:

| character | composed (NFC) | decomposed (NFD) |
|---|---|---|
| `ū` | U+016B, 2 bytes | `u` + U+0304 COMBINING MACRON, 3 bytes |
| `ḡ` | U+1E21, 3 bytes | `g` + U+0304, 3 bytes |
| `ṗ` | U+1E57, 3 bytes | `p` + U+0307, 3 bytes |
| `ñ` `é` | U+00F1 / U+00E9, 2 bytes | base + U+0303 / U+0301, 3 bytes |

Julia's parser NFC-normalizes identifiers, so **the two spellings are the same binding**. Verified rather than assumed (with `Ñ`, whose two forms are the easiest to write out):

```julia
julia> nfd = "Ñ"; nfc = "Ñ"          # "4ecc83" vs "c391"
julia> eval(Meta.parse(nfd * "_probe = 7"))   # assign through the decomposed spelling
julia> eval(Meta.parse(nfc * "_probe"))       # read through the composed one
7
julia> filter(n -> occursin("_probe", string(n)), names(Main, all=true))
1-element Vector{Symbol}: :Ñ_probe            # one binding, not two
```

So a file mixing them compiles and runs identically, and **no test of behaviour can distinguish them** — which is exactly what let this sit. What they are not is the same *text*:

- `grep ū` typed one way silently finds nothing while the identifier sits plainly on screen;
- an exact-string edit fails for no visible reason;
- a diff shows the line as modified while rendering byte-for-byte identically, so encoding churn is indistinguishable from a real edit.

Files drift between the forms without anyone touching a character, because macOS filesystem APIs hand back decomposed text and some editors recompose on save.

## The change

Seven files, 31 lines, 44 combining marks folded away:

| file | characters |
|---|---|
| `src/harmonic_oscillator.jl` | `ū` `ḡ` `ṗ` |
| `src/lotka_volterra_2d_common.jl` | `ū` `ḡ` `ṗ` |
| `src/lotka_volterra_2d_equations.jl` | `ū` `ḡ` |
| `src/lotka_volterra_2d_symmetric.jl` | `ñ` |
| `src/lotka_volterra_4d.jl` | `ṗ` |
| `README.md`, `docs/make.jl` | `é` (in *Hénon*) |

`src/toda_lattice.jl` was the eighth file until #110 landed: hand-writing the Toda vector fields rewrote its `Ñ` lines into NFC as a side effect, so this branch was rebased onto that and `Ñ` drops off the list. The rebase conflicted on exactly those seven lines and resolved in favour of #110's version, which is byte-identical to what normalization would have produced.

Every changed line is canonically equivalent to the one it replaces. Checked mechanically, not by eye: for each file, `NFC(before) == after`, **and** `NFD(before) == NFD(after)`, so nothing but the normal form changed.

Only 15 bytes are removed rather than 44, because the composed forms of `ṗ`, `ḡ` and `ẋ` are themselves three-byte codepoints and cost exactly what their decomposed spellings did.

## The guard

`test/unicode_normalization_tests.jl` keeps it this way. It asserts the *normal form of each file* rather than any particular character, so there is no list of accented identifiers to maintain, and it reports the offending paths rather than a count, so a failure says what to run `normalize` over.

Characters with no precomposed form pass untouched: `q̇` is `q` + U+0307 and has no single codepoint, so it is already in normal form and no normalization pass can change it. `obsolete/` is excluded, being kept for reference and not edited — its six files are the only decomposed text left in the tree.

`Unicode` is now a declared dependency in `test/Project.toml`, for the third time the same reason applies after `Logging` and `LinearAlgebra`: an undeclared stdlib resolves under `julia --project=test` but not inside the sandbox environment `Pkg.test` builds from that file, where `using Unicode` fails with *"Package Unicode not found in current path"*. The pre-push hook caught this, which is the whole point of it.

Full `Pkg.test()` passes, as does the pre-push hook suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
