### PR TITLE
Check every ensemble sample against N, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,18 @@ depended on the old form doing what it claimed.
   passed `parameters` raw to `lagrangian_system`/`hamiltonian_system` in one place and
   `_parameters(parameters)` in another, so a vector of parameter sets reached `symbolize`
   asymmetrically; both now use `_parameters`. `src/toda_lattice.jl`.
+- **Linear wave and Toda lattice**: the size assertion now checks **every sample** of an ensemble, not
+  just the first. `_nint`/`_length` report on `q₀[begin]`, so `hodeensemble(5, [q5, q7], …)` passed —
+  and so did a `p₀` whose samples disagreed with each other. Neither branch then complains: the
+  hand-written fields read the size off each state individually, so sample 2 is integrated as a
+  lattice of *its own* size, while the generated ones have one size baked in and write only the first
+  `N` components of an oversized sample's force, leaving the rest at whatever the buffer held. Measured
+  on a `[q5, q7]` ensemble at `t = 0.1`: the hand-written branch reproduces the true 7-site trajectory
+  exactly (so the samples are two different physical systems, silently), and the symbolic branch
+  departs from it by only `1.5e-6` — small enough to read as round-off, and growing with the window.
+  That is the failure mode the assertion was added to prevent, surviving for samples 2…n. Messages now
+  name the offending array and sample, `"q₀ sample 2 has 7 components, expected N = 5"`.
+  `src/linear_wave.jl`, `src/toda_lattice.jl`.
 - **Toda lattice**: removed the unused module-level `const Ω = compute_domain(Ñ, typeof(μ))`. It was
   a plot domain, referenced nowhere in `src/`, `test/`, `docs/` or `benchmark/`, and a module-level
   `Ω` that is *not* the two-form sitting next to the new `ω!` is a trap worth not setting.

--- a/src/linear_wave.jl
+++ b/src/linear_wave.jl
@@ -273,9 +273,25 @@ module LinearWave
     # The hand-written vector fields read the lattice size off the state while the symbolic ones have
     # it baked in, so an `N` that disagrees with the initial condition would silently mean two
     # different systems depending on `symbolic`. Reject it up front.
+    #
+    # *Every* sample of an ensemble is checked, not just the first one `_nint` reports on: the
+    # hand-written fields read the size off each state individually, so a ragged ensemble would
+    # integrate its samples as lattices of different sizes, while the generated ones have one size
+    # baked in and would leave the components past `N + 2` of an oversized sample without a force.
+    # Neither errors on its own, and neither is what was asked for.
     function _check_size(N, q₀, p₀)
-        @assert _nint(q₀) == N "initial condition has $(_nint(q₀) + 2) components, expected N + 2 = $(N + 2)"
-        @assert _nint(p₀) == N "initial condition has $(_nint(p₀) + 2) components, expected N + 2 = $(N + 2)"
+        _check_components(N, q₀, "q₀")
+        _check_components(N, p₀, "p₀")
+        nothing
+    end
+
+    _check_components(N, x::AbstractArray{<:Number}, name) =
+        @assert length(x) == N + 2 "$name has $(length(x)) components, expected N + 2 = $(N + 2)"
+
+    function _check_components(N, x::AbstractVector{<:AbstractArray}, name)
+        for (i, sample) in pairs(x)
+            @assert length(sample) == N + 2 "$name sample $i has $(length(sample)) components, expected N + 2 = $(N + 2)"
+        end
         nothing
     end
 

--- a/src/toda_lattice.jl
+++ b/src/toda_lattice.jl
@@ -269,9 +269,25 @@ _length(q::AbstractVector{<:AbstractArray}) = length(q[begin])
 # The hand-written vector fields read the lattice size off the state while the symbolic ones have it
 # baked in, so an `N` that disagrees with the initial condition would silently mean two different
 # systems depending on `symbolic`. Reject it up front.
+#
+# *Every* sample of an ensemble is checked, not just the first one `_length` reports on: the
+# hand-written fields read the size off each state individually, so a ragged ensemble would integrate
+# its samples as lattices of different sizes, while the generated ones have one size baked in and
+# would leave the components past `N` of an oversized sample without a force. Neither errors on its
+# own, and neither is what was asked for.
 function _check_size(N, q₀, p₀)
-    @assert _length(q₀) == N "initial condition has $(_length(q₀)) components, expected N = $N"
-    @assert _length(p₀) == N "initial condition has $(_length(p₀)) components, expected N = $N"
+    _check_components(N, q₀, "q₀")
+    _check_components(N, p₀, "p₀")
+    nothing
+end
+
+_check_components(N, x::AbstractArray{<:Number}, name) =
+    @assert length(x) == N "$name has $(length(x)) components, expected N = $N"
+
+function _check_components(N, x::AbstractVector{<:AbstractArray}, name)
+    for (i, sample) in pairs(x)
+        @assert length(sample) == N "$name sample $i has $(length(sample)) components, expected N = $N"
+    end
     nothing
 end
 

--- a/test/linear_wave_tests.jl
+++ b/test/linear_wave_tests.jl
@@ -1,4 +1,4 @@
-using GeometricEquations: HODEProblem, LODEProblem, functions, initialguess
+using GeometricEquations: HODEEnsemble, HODEProblem, LODEEnsemble, LODEProblem, functions, initialguess
 using GeometricIntegrators
 using GeometricProblems.LinearWave
 using GeometricSolutions
@@ -175,4 +175,26 @@ end
     # two different systems depending on `symbolic`.
     @test_throws AssertionError hodeproblem(N + 1, q₀, p₀)
     @test_throws AssertionError lodeproblem(N + 1, q₀, p₀)
+
+    # ...and every *sample* of an ensemble is checked, not just the first. A ragged ensemble is
+    # accepted by neither branch on its own merits: the hand-written fields would integrate sample 2
+    # as a lattice of its own size, and the generated ones — which have N baked in — would write only
+    # the first N + 2 components of its force and leave the rest at whatever the buffer held. Both run
+    # to completion without complaint, which is what makes the check the only thing standing here.
+    q₁ = [q₀; 0.1]      # one component too many
+    p₁ = [p₀; 0.0]
+
+    @test_throws AssertionError hodeensemble(N, [q₀, q₁], [p₀, p₀])
+    @test_throws AssertionError lodeensemble(N, [q₀, q₁], [p₀, p₀])
+    @test_throws AssertionError hodeensemble(N, [q₀, q₀], [p₀, p₁])
+    @test_throws AssertionError lodeensemble(N, [q₀, q₀], [p₀, p₁])
+
+    # The two-argument forms infer N from the first sample, so a ragged tail has to be caught there
+    # too rather than defining the lattice size out from under the rest.
+    @test_throws AssertionError hodeensemble([q₀, q₁], [p₀, p₀])
+    @test_throws AssertionError lodeensemble([q₀, q₁], [p₀, p₀])
+
+    # ...while a well-formed ensemble is of course still accepted, in both branches.
+    @test hodeensemble(N, [q₀, q₀ .+ 0.1], [p₀, p₀]) isa HODEEnsemble
+    @test lodeensemble(N, [q₀, q₀ .+ 0.1], [p₀, p₀]; symbolic = true) isa LODEEnsemble
 end

--- a/test/toda_lattice_tests.jl
+++ b/test/toda_lattice_tests.jl
@@ -263,6 +263,28 @@ end
     # two different systems depending on `symbolic`.
     @test_throws AssertionError hodeproblem(M + 1, qM, pM)
     @test_throws AssertionError lodeproblem(M + 1, qM, pM)
+
+    # ...and every *sample* of an ensemble is checked, not just the first. A ragged ensemble is
+    # accepted by neither branch on its own merits: the hand-written fields would integrate sample 2
+    # as a lattice of its own size, and the generated ones — which have N baked in — would write only
+    # the first N components of its force and leave the rest at whatever the buffer held. Both run to
+    # completion without complaint, which is what makes the check the only thing standing here.
+    qM1 = [qM; 0.1]     # one component too many
+    pM1 = [pM; 0.0]
+
+    @test_throws AssertionError hodeensemble(M, [qM, qM1], [pM, pM])
+    @test_throws AssertionError lodeensemble(M, [qM, qM1], [pM, pM])
+    @test_throws AssertionError hodeensemble(M, [qM, qM], [pM, pM1])
+    @test_throws AssertionError lodeensemble(M, [qM, qM], [pM, pM1])
+
+    # The two-argument forms infer N from the first sample, so a ragged tail has to be caught there
+    # too rather than defining the lattice size out from under the rest.
+    @test_throws AssertionError hodeensemble([qM, qM1], [pM, pM])
+    @test_throws AssertionError lodeensemble([qM, qM1], [pM, pM])
+
+    # ...while a well-formed ensemble is of course still accepted, in both branches.
+    @test hodeensemble(M, [qM, qM .+ 0.1], [pM, pM]) isa HODEEnsemble
+    @test lodeensemble(M, [qM, qM .+ 0.1], [pM, pM]; symbolic = true) isa LODEEnsemble
 end
 
 # The ensembles above are hand-written now, so the symbolic branch of `hodeensemble`/`lodeensemble` —


### PR DESCRIPTION
Second follow-up to the review of #110, and **stacked on it** — it targets `feature/toda-lattice-handwritten-equations` rather than `main`, because `TodaLattice._check_size` only exists on that branch. The diff here is just the fix.

The other follow-up, #111, is independent and targets `main`.

## The problem

`_check_size` asked `_nint`/`_length` for the size of the initial condition, and for an ensemble those report on `q₀[begin]` alone:

```julia
_length([q5, q7])                    # 5
_check_size(5, [q5, q7], [p5, p7])   # accepted
_check_size(5, [q5, q5], [p5, p7])   # accepted — ragged momenta too
_check_size(7, [q5, q7], [p5, p7])   # throws: "initial condition has 5 components, expected N = 7"
```

That last line is the shape of the bug in miniature: the assertion *does* fire, but it reports on sample 1 while the mismatch is in sample 2. The two-argument forms compound it, since they assert only that `q₀` and `p₀` hold the same *number of samples*, not that the samples agree in length.

## What a ragged ensemble actually did

Measured, not reasoned about — a `[q5, q7]` ensemble declared as `N = 5`, integrated to `t = 0.1` with `ImplicitMidpoint`. Both branches run to completion without complaint, and they fail differently:

**Hand-written branch.** The fields read `N = length(q)` off each state, so sample 2 is a bona fide 7-site periodic lattice:

```
sample sizes 5 and 7;  |sample1 − true 5-site| = 0.0;  |sample2 − true 7-site| = 0.0
```

The numbers are right. The defect is that you asked for a five-site ensemble and got two *different physical systems*, with nothing saying so — every cross-sample comparison downstream is then meaningless while looking perfectly well-behaved.

**Symbolic branch — the worse one.** The generated functions have `N = 5` compiled in. Called directly on a seven-component state:

```
generated f writes 5 of 7 entries; untouched tail = [NaN, NaN]
hand-written f writes 7 of 7
```

Sites 6 and 7 never receive a force — in the integrator they get whatever the buffer held. The giveaway is how quietly:

```
|sample2 − true 7-site| = 1.48e-6
```

after only `t = 0.1`. Small because the default momentum is zero and the window is short, not because anything is right; it grows with the window. That is the failure mode that survives a casual look.

Either way, this is exactly what the assertion's own comment says it exists to prevent — *"an `N` that disagrees with the initial condition would silently mean two different systems depending on `symbolic`"* — surviving for samples 2…n.

## The change

`_check_components` replaces the single length query: one method for a plain initial condition, one that walks `pairs(x)` for a vector of samples. Messages now name the array and the sample:

```
q₀ sample 2 has 7 components, expected N = 5
```

`_nint`/`_length` stay — the two-argument constructors still use them to infer `N` from the first sample, which is the right behaviour once the rest are checked against it.

**Both modules are fixed together.** `src/linear_wave.jl` had the identical first-sample-only shape; they carry the same helper by design, and fixing one alone would leave the next reader wondering which is intentional.

## Tests

`test/toda_lattice_tests.jl`: the size testset goes 14 → 22 assertions. `test/linear_wave_tests.jl`: 11 → 19. Each covers a ragged `q₀`, a ragged `p₀`, both the `N`-form and the two-argument form, and — as the positive control — a well-formed ensemble in each of the two branches:

```julia
@test_throws AssertionError hodeensemble(M, [qM, qM1], [pM, pM])
@test_throws AssertionError hodeensemble(M, [qM, qM], [pM, pM1])
@test_throws AssertionError hodeensemble([qM, qM1], [pM, pM])       # two-argument form
@test hodeensemble(M, [qM, qM .+ 0.1], [pM, pM]) isa HODEEnsemble
@test lodeensemble(M, [qM, qM .+ 0.1], [pM, pM]; symbolic = true) isa LODEEnsemble
```

`linear_wave_tests.jl` needed `HODEEnsemble`/`LODEEnsemble` added to its imports, having previously used only the problem types.

Full `Pkg.test()` passes, as does the pre-push hook suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
