### PR TITLE
Update for GeometricIntegrators 0.17 and SimpleSolvers 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,32 @@ numerical and observational, and it invalidated three things the repository had 
   because the Poincaré-invariant constructors are still wired through `Requires.@require`; that
   mechanism fires on the package being loaded regardless of how it is declared. Verified that
   GeometricProblems and PoincareInvariants 0.5.0 still co-resolve.
+- **`Requires` is gone, replaced by a `LotkaVolterra2dPoincareInvariants` extension.** The first
+  Poincaré invariant was the package's only use of `Requires`, so dropping the `@require` block
+  drops the dependency with it; `ext/LotkaVolterra2dPoincareInvariants.jl` now carries the two
+  methods, in the same shape as the `*Plots` extensions, and the parent modules gained
+  `function ode_poincare_invariant_1st end` / `iode_poincare_invariant_1st end` stubs as the plot
+  functions already had.
+
+  **The code is still dead, deliberately.** It calls `PoincareInvariant1st`, removed in
+  PoincareInvariants 0.5.0, on `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are pre-0.7
+  constructor names; calling either method throws `UndefVarError`, exactly as it did before the
+  move. It is carried over unchanged rather than repaired because the Poincaré-invariant support
+  needs a complete makeover and the upstream interface is still being tuned, so 0.5 is not the
+  target to write against.
+
+  What the move buys is visibility. `Requires` defers its block to load time, and since nothing in
+  the suite or the docs loads PoincareInvariants, both call paths rotted through at least two
+  renames without anything noticing. An extension is precompiled, so the file is now parsed and
+  loaded by CI. One small behavioural consequence: the two names are now always defined (as
+  functions with no methods) rather than springing into existence when PoincareInvariants is
+  loaded — again matching the plot functions.
+
+  `lotka_volterra_2d_equations.jl` is included into all four Lotka-Volterra 2d modules, so all four
+  export these names and the extension defines methods for all four. That is preserved as-is; if
+  the makeover decides the invariants belong only on `LotkaVolterra2d`, pruning the other three is
+  a separate call. The neighbouring `ode_loop`/`iode_loop` helpers are dead for the same reason and
+  were left alone — they are unexported and are not used by the invariant code.
 
 ## [0.8.1] — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,12 +76,19 @@ numerical and observational, and it invalidated three things the repository had 
 
   The helper filters by originating module (`nameof(l._module) === :SimpleSolvers`) rather than
   using `@test_nowarn`, both to ignore the unrelated `GeometricEquations` single-sample-ensemble
-  warning and because SimpleSolvers must stay a transitive-only dependency. That makes the
-  `:SimpleSolvers` symbol load-bearing: were those messages to move module, the filter would match
-  nothing and the assertion would pass vacuously. The comment now says so, and the filter was
-  confirmed to actually match by the three-body measurement above, where the same expression
-  counted 5, 9, 4, 4 and 4 messages.
-- **The full suite emits zero SimpleSolvers messages** — 930 assertions, no failures, no errors,
+  warning and because SimpleSolvers must stay a transitive-only dependency. Records from every
+  other module are re-emitted to the enclosing logger instead of being swallowed with them, so
+  applying the helper to a call site does not blind it to unrelated warnings.
+- **A positive control keeps the silence assertions from passing vacuously.** Filtering on
+  `:SimpleSolvers` makes that symbol load-bearing: were those messages to move module, the filter
+  would match nothing and all 33 call sites would keep passing while asserting nothing. Since the
+  suite emits zero SimpleSolvers messages, no run of it can tell the two cases apart. The last test
+  in `three_body_tests.jl` closes that gap by integrating the collisional
+  `sympnets_initial_condition` over ``t \in [0, 1]`` at ``\Delta{}t = 0.5`` — the case
+  `DEFAULT_TIMESTEP` documents as unintegrable — and asserting the *same* expression reports
+  something. It currently catches four distinct messages (three line-search reports and one
+  iteration-limit report), and fails if the filter ever stops matching.
+- **The full suite emits zero SimpleSolvers messages** — 972 assertions, no failures, no errors,
   and no warnings from any module at all. For scale, the historical counts recorded below (5453 in
   the Euler-Lagrange ensembles test, 1341 in the three-body test, 2554 in a docs build) were fixed
   by changing the default initial condition away from the collisional grid, not by fixing the
@@ -89,37 +96,41 @@ numerical and observational, and it invalidated three things the repository had 
   effects are no longer confounded.
 
 ### Repository hygiene
-- **Seven `examples/*.jl` rewritten against the current API.** `lotka_volterra_2d.jl`,
-  `lotka_volterra_2d_singular.jl`, `lotka_volterra_2d_symmetric.jl`, `lotka_volterra_3d.jl`,
-  `lotka_volterra_4d.jl`, `massless_charged_particle_2d.jl` and `point_vortices_test.jl` had been
-  broken against GeometricIntegrators for years and are invisible to both `runtests.jl` and
-  `docs/make.jl`, so nothing caught it: they used `set_config(:nls_atol, …)`,
-  `GeometricIntegrators.Integrators.VPRK`, the `getTableau*` factories, the `Integrator*` types and
-  `Solution(ode, Δt, nt)` + `integrate!`, and plotted through `Plots` with function names that no
-  longer exist. Each was ~420 lines of which roughly four fifths was a commented-out tableau menu.
+- **Seven `examples/*.jl` added.** `lotka_volterra_2d.jl`, `lotka_volterra_2d_singular.jl`,
+  `lotka_volterra_2d_symmetric.jl`, `lotka_volterra_3d.jl`, `lotka_volterra_4d.jl`,
+  `massless_charged_particle_2d.jl` and `point_vortices.jl`. Before this the directory held only
+  `pendulum.jl` and `harmonic_oscillator.jl`; scripts for these seven problems existed as untracked
+  local files, never committed, and had rotted against GeometricIntegrators years ago — they used
+  `set_config(:nls_atol, …)`, `GeometricIntegrators.Integrators.VPRK`, the `getTableau*` factories,
+  the `Integrator*` types and `Solution(ode, Δt, nt)` + `integrate!`, and plotted through `Plots`
+  with function names that no longer exist. Each was ~420 lines of which roughly four fifths was a
+  commented-out tableau menu. Nothing would have caught that in any case: `examples/` is invisible
+  to both `runtests.jl` and `docs/make.jl`.
 
-  They are now written in the shape of `examples/pendulum.jl` — the one example that had stayed
-  current — as a table of `(name, problem, method)` runs over `integrate(problem, method)`, plotted
-  with the Makie extension functions and saved as one PDF per run. The method/formulation pairings
-  are taken from the corresponding test file, so they are known-good. All seven run to completion.
-  `LotkaVolterra2dSingular` and `LotkaVolterra2dSymmetric` have no plot extension of their own, so
-  they reuse `LotkaVolterra2d`'s, which are generic in the solution and the problem.
+  The committed versions are written in the shape of `examples/pendulum.jl` — the one example that
+  had stayed current — as a table of `(name, problem, method)` runs over `integrate(problem,
+  method)`, plotted with the Makie extension functions and saved as one PDF per run, next to the
+  script via `@__DIR__`. The method/formulation pairings are taken from the corresponding test
+  file, so they are known-good. All seven run to completion. `LotkaVolterra2dSingular` and
+  `LotkaVolterra2dSymmetric` have no plot extension of their own, so they reuse `LotkaVolterra2d`'s,
+  which are generic in the solution and the problem.
 
   The five scratch variants — `lotka_volterra_2d_{debug,regression,simplified,test}.jl` and
-  `harmonic_oscillator_legacy.jl` — were left untouched and remain broken.
+  `harmonic_oscillator_legacy.jl` — remain untracked and broken.
 - **The root `Project.toml`'s `[extras]` block is gone.** It listed `ForwardDiff`,
   `GeometricIntegrators`, `GeometricSolutions`, `SafeTestsets` and `Test` but there was no
   `[targets]` section, and `test/Project.toml` takes precedence over `[targets]` anyway, so the
   block did nothing; all five are properly declared in `test/Project.toml`. `PoincareInvariants`
-  moved to `[weakdeps]` with a `PoincareInvariants = "0.5"` compat bound, which is where an
-  optional dependency belongs in this package — `Makie` is already there — and unlike `[extras]`
-  it is actually resolved, so the bound is enforced. There is no accompanying `[extensions]` entry
-  because the Poincaré-invariant constructors are still wired through `Requires.@require`; that
-  mechanism fires on the package being loaded regardless of how it is declared. Verified that
-  GeometricProblems and PoincareInvariants 0.5.0 still co-resolve.
+  moved to `[weakdeps]`, which is where an optional dependency belongs in this package — `Makie` is
+  already there — with an accompanying `[extensions]` entry (see below). Its compat bound is
+  `"0.4, 0.5"`: unlike `[extras]`, a weakdep bound is actually resolved and therefore enforced, and
+  bounding to `"0.5"` alone would have excluded 0.4 — the last line on which the extension's bodies
+  would in fact run — while admitting only the line on which they cannot. Both are allowed until
+  the makeover picks a target. Verified that GeometricProblems and PoincareInvariants 0.5.0
+  co-resolve.
 - **`Requires` is gone, replaced by a `LotkaVolterra2dPoincareInvariants` extension.** The first
   Poincaré invariant was the package's only use of `Requires`, so dropping the `@require` block
-  drops the dependency with it; `ext/LotkaVolterra2dPoincareInvariants.jl` now carries the two
+  drops the dependency with it; `ext/LotkaVolterra2dPoincareInvariants.jl` now carries those
   methods, in the same shape as the `*Plots` extensions, and the parent modules gained
   `function ode_poincare_invariant_1st end` / `iode_poincare_invariant_1st end` stubs as the plot
   functions already had.
@@ -131,22 +142,24 @@ numerical and observational, and it invalidated three things the repository had 
   needs a complete makeover and the upstream interface is still being tuned, so 0.5 is not the
   target to write against.
 
-  What the move buys is the *possibility* of visibility. `Requires` defers its block to load time,
-  and since nothing in the suite or the docs loads PoincareInvariants, both call paths rotted
-  through at least two renames without anything noticing. An extension is precompiled — but only in
-  an environment that has its trigger package, and `test/Project.toml` still does not list
-  PoincareInvariants, so this code is not in front of CI yet either. Adding it there is the
-  remaining step, and is noted as such. One small behavioural consequence of the move: the two
-  names are now always defined (as functions with no methods) rather than springing into existence
-  when PoincareInvariants is loaded — again matching the plot functions.
+  What the move buys is visibility. `Requires` defers its block to load time, and since nothing in
+  the suite or the docs loaded PoincareInvariants, both call paths rotted through at least two
+  renames without anything noticing. An extension is precompiled — but only in an environment that
+  has its trigger package, so `test/Project.toml` now lists PoincareInvariants purely as that
+  trigger, and the new `test/poincare_invariants_tests.jl` asserts that the extension resolves,
+  that Pkg attaches it, and that it reaches all four Lotka-Volterra 2d modules. It also pins the
+  dead bodies to the `UndefVarError` they currently throw, so a repair has to come past a test. One
+  small behavioural consequence of the move: the invariant names are now always defined (as
+  functions with no methods) rather than springing into existence when PoincareInvariants is loaded
+  — again matching the plot functions.
 
-  The loop scaffolding moved with it: `initial_conditions_loop`, `ode_loop` and `iode_loop` are
-  unexported, are used by nothing outside this cluster, and now live in the extension too, leaving
-  the whole Poincaré-invariant surface in one file. `ode_loop`/`iode_loop` are dead for the same
-  reason as the invariants — they call `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode` —
-  while `initial_conditions_loop` does work and continues to. Only `f_loop` stays in `src/`: it
-  parameterises the loop in phase space and is handed to the invariant as data, so both the
-  extension's `initial_conditions_loop` and its invariant methods read it off the module.
+  The two problem wrappers moved with it: `ode_loop` and `iode_loop` are unexported, are used by
+  nothing outside this cluster, and are dead for the same reason as the invariants — they call
+  `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`. `f_loop` and `initial_conditions_loop` stay in
+  `src/` instead. They parameterise and sample the loop in phase space, they are the only part of
+  the cluster that works, and they need nothing from PoincareInvariants — moving them would have
+  made a working function raise a `MethodError` unless an unrelated optional dependency happened to
+  be loaded. The extension reads both off the parent module.
 
   `lotka_volterra_2d_equations.jl` is included into all four Lotka-Volterra 2d modules, so all four
   export these names and the extension defines methods for all four. That is preserved as-is; if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,12 +131,14 @@ numerical and observational, and it invalidated three things the repository had 
   needs a complete makeover and the upstream interface is still being tuned, so 0.5 is not the
   target to write against.
 
-  What the move buys is visibility. `Requires` defers its block to load time, and since nothing in
-  the suite or the docs loads PoincareInvariants, both call paths rotted through at least two
-  renames without anything noticing. An extension is precompiled, so the file is now parsed and
-  loaded by CI. One small behavioural consequence: the two names are now always defined (as
-  functions with no methods) rather than springing into existence when PoincareInvariants is
-  loaded — again matching the plot functions.
+  What the move buys is the *possibility* of visibility. `Requires` defers its block to load time,
+  and since nothing in the suite or the docs loads PoincareInvariants, both call paths rotted
+  through at least two renames without anything noticing. An extension is precompiled — but only in
+  an environment that has its trigger package, and `test/Project.toml` still does not list
+  PoincareInvariants, so this code is not in front of CI yet either. Adding it there is the
+  remaining step, and is noted as such. One small behavioural consequence of the move: the two
+  names are now always defined (as functions with no methods) rather than springing into existence
+  when PoincareInvariants is loaded — again matching the plot functions.
 
   The loop scaffolding moved with it: `initial_conditions_loop`, `ode_loop` and `iode_loop` are
   unexported, are used by nothing outside this cluster, and now live in the extension too, leaving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,16 @@ numerical and observational, and it invalidated three things the repository had 
 
   The five scratch variants — `lotka_volterra_2d_{debug,regression,simplified,test}.jl` and
   `harmonic_oscillator_legacy.jl` — were left untouched and remain broken.
+- **The root `Project.toml`'s `[extras]` block is gone.** It listed `ForwardDiff`,
+  `GeometricIntegrators`, `GeometricSolutions`, `SafeTestsets` and `Test` but there was no
+  `[targets]` section, and `test/Project.toml` takes precedence over `[targets]` anyway, so the
+  block did nothing; all five are properly declared in `test/Project.toml`. `PoincareInvariants`
+  moved to `[weakdeps]` with a `PoincareInvariants = "0.5"` compat bound, which is where an
+  optional dependency belongs in this package — `Makie` is already there — and unlike `[extras]`
+  it is actually resolved, so the bound is enforced. There is no accompanying `[extensions]` entry
+  because the Poincaré-invariant constructors are still wired through `Requires.@require`; that
+  mechanism fires on the package being loaded regardless of how it is declared. Verified that
+  GeometricProblems and PoincareInvariants 0.5.0 still co-resolve.
 
 ## [0.8.1] — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,103 @@ Categories: **Bug fixes** = code defects (typos, wrong API calls, crashes, bad i
 > Development notes for the 0.7.0 correctness audit — the original findings report, its
 > remediation plan and the execution log — are archived under [`docs/dev/`](docs/dev/).
 
+## [0.8.2] — 2026-08-06
+
+Update to GeometricIntegrators 0.17, and with it SimpleSolvers 0.10.1 and
+GeometricIntegratorsBase 0.5.1. None of the breaking changes in that line reach this package —
+`solversize`/`nullvectorsize` flipping to `(method, problem)` and `default_options` becoming a
+required two-argument method affect only code that defines or calls them, and every call site here
+uses the positional `integrate(problem, method)` form, which is unchanged. `src/` and `ext/`
+contain no GeometricIntegrators or SimpleSolvers code at all. What changed for this package is
+numerical and observational, and it invalidated three things the repository had written down.
+
+### Changed
+- **Dependency bounds.** `test/`, `docs/` and `examples/` each gained a `[compat]` section; none of
+  the three had one, so nothing constrained which GeometricIntegrators they resolved and they had
+  drifted apart — `test/` was on 0.16.9, `docs/` on 0.16.7 and `examples/` on 0.16.2 with
+  SimpleSolvers 0.8.4. All three now require `GeometricIntegrators = "0.17"` and resolve
+  SimpleSolvers 0.10.1 and GeometricIntegratorsBase 0.5.1. As in GeometricIntegrators itself, the
+  bound lives where the dependency is resolved rather than in the root project; the root
+  `[extras]` block remains inert, since `test/Project.toml` takes precedence over `[targets]`.
+- **The default residual tolerance moved, and nothing here noticed.** GeometricIntegratorsBase
+  0.5.1 sets `f_abstol = max(8, solversize(method, problem)) * eps(datatype(problem))` —
+  size-dependent, 1.8e-15 … ~1.1e-14 — where 0.16.x used a flat `8eps()`. No test threshold needed
+  re-tuning: the tightest assertions in the suite retain at least a factor of five. Measured on the
+  three-body figure-eight over one period with `Gauss(2)`, the quantities the docstrings quote are
+  unmoved — energy error 2.66e-15 (bound 1e-12, docstring "3e-15") and orbit closure 1.28e-7 in `q`
+  and 1.97e-7 in `p` (bound 1e-6, docstring "1.3e-7") — and the Hamiltonian/Lagrangian agreement
+  sits at 5.4e-17 and 1.03e-16 against a bound of 1e-14.
+
+### Documentation
+- **The three-body warning counts are re-measured.** `src/three_body_problem.jl`'s
+  `DEFAULT_TIMESTEP` docstring recorded that, over `t ∈ [0, 1]` on the collisional
+  `sympnets_initial_condition`, the default Newton method emitted 596, 1346, 390, 321 and 361
+  warnings at `Δt = 0.5, 0.05, 0.01, 0.005, 0.001` against 1–2 for the trust-region `DogLeg`; the
+  paragraph existed to explain that the trust region was merely quieter about the same failure and
+  that the default Newton solver should therefore stay. Under SimpleSolvers 0.10 the counts
+  are 5, 9, 4, 4, 4 for Newton and 6, 1, 1, 5, 6 for `DogLeg` — the asymmetry has gone, because
+  0.10 caps repeated reports with `maxlog` and stops a stagnating solve after `max_stalls` rather
+  than letting it spin to `max_iterations`. The message count now measures how a failure is
+  *reported*, not how badly it fails. The paragraph was rewritten around the energy error instead:
+  19, 15, 36, 399 and 249 for Newton against 9, 45, 12, 1615 and 2.2e6 for `DogLeg`, with the two
+  ending up 0.6, 3.8, 5.0, 50 and 1209 apart in `q`. The conclusion is unchanged — neither solver
+  can integrate the collision, so the default Newton solver is kept — but it now rests on a
+  quantity that means something.
+- **`docs/src/pendulum.md` no longer disables logging.** The `using Logging # hide` /
+  `Logging.disable_logging(Logging.Warn) # hide` pair existed to hide the old SimpleSolvers flood
+  and suppressed every warning on the page along with it. Removed; the docs build is clean without
+  it.
+
+### Tests
+- **`integrate_quietly` extracted to `test/integrate_quietly.jl` and applied sixfold.** It was
+  defined inline in `eulerlagrange_ensembles_tests.jl` and is the one assertion in these packages
+  that asserts SimpleSolvers *silence* rather than suppressing it — which was only worth
+  generalising once 0.10 made a converging solve genuinely silent. Before that, a line search built
+  its own `Options` and never saw the solver's `verbosity`, so a converged solve reported its
+  round-off floor as a warning and which orbits tripped it depended on platform floating-point
+  details. It now also guards `three_body_tests.jl`, `toda_lattice_tests.jl`,
+  `linear_wave_tests.jl`, `coupled_harmonic_oscillator_tests.jl`, `outer_solar_system_tests.jl` and
+  `perturbed_pendulum_tests.jl` — 26 further call sites, all passing.
+
+  It was deliberately *not* applied to the SPARK and VPRK-projection suites
+  (`lotka_volterra_2d*`, `lotka_volterra_4d*`, `massless_charged_particle*`, `point_vortices*`) or
+  to the unequal-mass three-body runs: some of those tableaux are marginal, and a stagnation
+  warning there is information rather than noise.
+
+  The helper filters by originating module (`nameof(l._module) === :SimpleSolvers`) rather than
+  using `@test_nowarn`, both to ignore the unrelated `GeometricEquations` single-sample-ensemble
+  warning and because SimpleSolvers must stay a transitive-only dependency. That makes the
+  `:SimpleSolvers` symbol load-bearing: were those messages to move module, the filter would match
+  nothing and the assertion would pass vacuously. The comment now says so, and the filter was
+  confirmed to actually match by the three-body measurement above, where the same expression
+  counted 5, 9, 4, 4 and 4 messages.
+- **The full suite emits zero SimpleSolvers messages** — 930 assertions, no failures, no errors,
+  and no warnings from any module at all. For scale, the historical counts recorded below (5453 in
+  the Euler-Lagrange ensembles test, 1341 in the three-body test, 2554 in a docs build) were fixed
+  by changing the default initial condition away from the collisional grid, not by fixing the
+  solver; SimpleSolvers 0.10 now reports stagnation properly rather than flooding, so the two
+  effects are no longer confounded.
+
+### Repository hygiene
+- **Seven `examples/*.jl` rewritten against the current API.** `lotka_volterra_2d.jl`,
+  `lotka_volterra_2d_singular.jl`, `lotka_volterra_2d_symmetric.jl`, `lotka_volterra_3d.jl`,
+  `lotka_volterra_4d.jl`, `massless_charged_particle_2d.jl` and `point_vortices_test.jl` had been
+  broken against GeometricIntegrators for years and are invisible to both `runtests.jl` and
+  `docs/make.jl`, so nothing caught it: they used `set_config(:nls_atol, …)`,
+  `GeometricIntegrators.Integrators.VPRK`, the `getTableau*` factories, the `Integrator*` types and
+  `Solution(ode, Δt, nt)` + `integrate!`, and plotted through `Plots` with function names that no
+  longer exist. Each was ~420 lines of which roughly four fifths was a commented-out tableau menu.
+
+  They are now written in the shape of `examples/pendulum.jl` — the one example that had stayed
+  current — as a table of `(name, problem, method)` runs over `integrate(problem, method)`, plotted
+  with the Makie extension functions and saved as one PDF per run. The method/formulation pairings
+  are taken from the corresponding test file, so they are known-good. All seven run to completion.
+  `LotkaVolterra2dSingular` and `LotkaVolterra2dSymmetric` have no plot extension of their own, so
+  they reuse `LotkaVolterra2d`'s, which are generic in the solution and the problem.
+
+  The five scratch variants — `lotka_volterra_2d_{debug,regression,simplified,test}.jl` and
+  `harmonic_oscillator_legacy.jl` — were left untouched and remain broken.
+
 ## [0.8.1] — 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,11 +138,18 @@ numerical and observational, and it invalidated three things the repository had 
   functions with no methods) rather than springing into existence when PoincareInvariants is
   loaded — again matching the plot functions.
 
+  The loop scaffolding moved with it: `initial_conditions_loop`, `ode_loop` and `iode_loop` are
+  unexported, are used by nothing outside this cluster, and now live in the extension too, leaving
+  the whole Poincaré-invariant surface in one file. `ode_loop`/`iode_loop` are dead for the same
+  reason as the invariants — they call `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode` —
+  while `initial_conditions_loop` does work and continues to. Only `f_loop` stays in `src/`: it
+  parameterises the loop in phase space and is handed to the invariant as data, so both the
+  extension's `initial_conditions_loop` and its invariant methods read it off the module.
+
   `lotka_volterra_2d_equations.jl` is included into all four Lotka-Volterra 2d modules, so all four
   export these names and the extension defines methods for all four. That is preserved as-is; if
   the makeover decides the invariants belong only on `LotkaVolterra2d`, pruning the other three is
-  a separate call. The neighbouring `ode_loop`/`iode_loop` helpers are dead for the same reason and
-  were left alone — they are unexported and are not used by the invariant code.
+  a separate call.
 
 ## [0.8.1] — 2026-07-30
 

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 Documenter = "1"
@@ -26,21 +25,17 @@ Parameters = "0.12, 0.13"
 Reexport = "1"
 Makie = "0.21, 0.22, 0.23, 0.24"
 PoincareInvariants = "0.5"
-Requires = "1"
 julia = "1.10"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 PoincareInvariants = "26663084-47d3-540f-bd97-40ca743aafa4"
 
-# PoincareInvariants has no extension: `LotkaVolterra2d`'s Poincaré-invariant constructors are
-# still wired through `Requires.@require` in `src/lotka_volterra_2d_equations.jl`. It is declared
-# here rather than in `[extras]` so that the optional dependency is resolvable and can carry a
-# compat bound; the `@require` block fires on the package being loaded either way.
 [extensions]
 DiagnosticsPlots = "Makie"
 HarmonicOscillatorPlots = "Makie"
 LotkaVolterra2dPlots = "Makie"
+LotkaVolterra2dPoincareInvariants = "PoincareInvariants"
 LotkaVolterra3dPlots = "Makie"
 LotkaVolterra4dPlots = "Makie"
 MasslessChargedParticlePlots = "Makie"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricProblems"
 uuid = "18cb22b4-ad41-5c80-9c5f-710df63fbdc9"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ NaNMath = "1"
 Parameters = "0.12, 0.13"
 Reexport = "1"
 Makie = "0.21, 0.22, 0.23, 0.24"
-PoincareInvariants = "0.5"
+PoincareInvariants = "0.4, 0.5"
 julia = "1.10"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -25,12 +25,18 @@ NaNMath = "1"
 Parameters = "0.12, 0.13"
 Reexport = "1"
 Makie = "0.21, 0.22, 0.23, 0.24"
+PoincareInvariants = "0.5"
 Requires = "1"
 julia = "1.10"
 
 [weakdeps]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+PoincareInvariants = "26663084-47d3-540f-bd97-40ca743aafa4"
 
+# PoincareInvariants has no extension: `LotkaVolterra2d`'s Poincaré-invariant constructors are
+# still wired through `Requires.@require` in `src/lotka_volterra_2d_equations.jl`. It is declared
+# here rather than in `[extras]` so that the optional dependency is resolvable and can carry a
+# compat bound; the `@require` block fires on the package being loaded either way.
 [extensions]
 DiagnosticsPlots = "Makie"
 HarmonicOscillatorPlots = "Makie"
@@ -40,11 +46,3 @@ LotkaVolterra4dPlots = "Makie"
 MasslessChargedParticlePlots = "Makie"
 PendulumPlots = "Makie"
 PointVorticesPlots = "Makie"
-
-[extras]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-GeometricIntegrators = "dcce2d33-59f6-5b8d-9047-0defad88ae06"
-GeometricSolutions = "7843afe4-64f4-4df4-9231-049495c56661"
-PoincareInvariants = "26663084-47d3-540f-bd97-40ca743aafa4"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,3 +10,15 @@ LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 
 [sources]
 GeometricProblems = {path = ".."}
+
+# As in `test/`, GeometricIntegrators is bounded where it is resolved rather than in the root
+# project. 0.17 is what pulls in SimpleSolvers 0.10.
+[compat]
+CairoMakie = "0.15"
+Documenter = "1"
+DocumenterCitations = "1"
+GeometricEquations = "0.21"
+GeometricIntegrators = "0.17"
+GeometricSolutions = "0.6.5"
+LaTeXStrings = "1"
+julia = "1.10"

--- a/docs/src/pendulum.md
+++ b/docs/src/pendulum.md
@@ -66,8 +66,6 @@ The canonical Hamiltonian dynamics is provided by `hodeproblem`, which can be in
 using GeometricProblems.Pendulum
 using GeometricIntegrators
 using CairoMakie
-using Logging # hide
-Logging.disable_logging(Logging.Warn) # hide
 
 prob = hodeproblem([1.0], [0.0]; timespan = (0.0, 20.0), timestep = 0.05)
 sol = integrate(prob, ImplicitMidpoint())

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -5,3 +5,10 @@ GeometricProblems = "18cb22b4-ad41-5c80-9c5f-710df63fbdc9"
 
 [sources]
 GeometricProblems = {path = ".."}
+
+# The examples are not run by CI, so without a bound here they drifted four minor versions behind
+# `test/` and `docs/`. 0.17 is what pulls in SimpleSolvers 0.10.
+[compat]
+CairoMakie = "0.15"
+GeometricIntegrators = "0.17"
+julia = "1.10"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -6,8 +6,8 @@ GeometricProblems = "18cb22b4-ad41-5c80-9c5f-710df63fbdc9"
 [sources]
 GeometricProblems = {path = ".."}
 
-# The examples are not run by CI, so without a bound here they drifted four minor versions behind
-# `test/` and `docs/`. 0.17 is what pulls in SimpleSolvers 0.10.
+# The examples are not run by CI, so this bound is the only thing keeping them in step with `test/`
+# and `docs/`. 0.17 is what pulls in SimpleSolvers 0.10.
 [compat]
 CairoMakie = "0.15"
 GeometricIntegrators = "0.17"

--- a/examples/lotka_volterra_2d.jl
+++ b/examples/lotka_volterra_2d.jl
@@ -1,0 +1,35 @@
+# Lotka-Volterra 2d: a survey of integrators
+#
+# Integrates the same system with a representative selection of the methods GeometricIntegrators
+# offers for it, and writes one PDF per method next to this script. Each figure shows the time
+# traces x₁(t), x₂(t) together with the relative energy error, which is the quantity these methods
+# are built to preserve.
+#
+# The problem is available in several formulations — ODE, implicit ODE, and implicit DAE — and not
+# every method applies to every one of them. The pairings below are the ones exercised in
+# `test/lotka_volterra_2d_tests.jl`.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.LotkaVolterra2d
+
+# The module defaults are t ∈ [0, 10] at Δt = 0.01, which is a thousand steps and runs in about a
+# second per method. Widen the timespan to see the energy error develop.
+const timespan = (0.0, 10.0)
+const timestep = 0.01
+
+const runs = (
+    ("gauss2",                    odeproblem(;  timespan, timestep), Gauss(2)),
+    ("gauss8",                    odeproblem(;  timespan, timestep), Gauss(8)),
+    ("vprk-gauss2-midpoint",      iodeproblem(; timespan, timestep), MidpointProjection(VPRKGauss(2))),
+    ("vprk-gauss2-symmetric",     iodeproblem(; timespan, timestep), SymmetricProjection(VPRKGauss(2))),
+    ("vspark-glrk2-midpoint",     idaeproblem(; timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+    ("vspark-glrk2-symmetric",    idaeproblem(; timespan, timestep), TableauVSPARKGLRKpSymmetric(2)),
+)
+
+for (name, problem, method) in runs
+    println("Integrating lotka_volterra_2d with $(name) ...")
+    solution = integrate(problem, method)
+    save("lotka_volterra_2d-$(name).pdf", plot_traces(solution, problem))
+end

--- a/examples/lotka_volterra_2d.jl
+++ b/examples/lotka_volterra_2d.jl
@@ -31,5 +31,5 @@ const runs = (
 for (name, problem, method) in runs
     println("Integrating lotka_volterra_2d with $(name) ...")
     solution = integrate(problem, method)
-    save("lotka_volterra_2d-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "lotka_volterra_2d-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/lotka_volterra_2d_singular.jl
+++ b/examples/lotka_volterra_2d_singular.jl
@@ -1,0 +1,32 @@
+# Lotka-Volterra 2d with a singular Lagrangian: a survey of integrators
+#
+# Same system and same methods as `lotka_volterra_2d.jl`, but built from a Lagrangian whose
+# Hessian is singular, so the implicit formulations are genuinely degenerate. This is the case
+# variational and SPARK integrators exist for, and the one where an unprojected method drifts.
+#
+# `LotkaVolterra2dSingular` has no plot extension of its own — only `LotkaVolterra2d` does — but
+# those plot functions are generic in the solution and the problem, so they are reused here.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.LotkaVolterra2dSingular
+
+import GeometricProblems.LotkaVolterra2d: plot_traces
+
+const timespan = (0.0, 10.0)
+const timestep = 0.01
+
+const runs = (
+    ("gauss2",                 odeproblem(;  timespan, timestep), Gauss(2)),
+    ("vprk-gauss2-midpoint",   iodeproblem(; timespan, timestep), MidpointProjection(VPRKGauss(2))),
+    ("vprk-gauss2-symmetric",  iodeproblem(; timespan, timestep), SymmetricProjection(VPRKGauss(2))),
+    ("vspark-glrk2-midpoint",  idaeproblem(; timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+    ("vspark-glrk2-symmetric", idaeproblem(; timespan, timestep), TableauVSPARKGLRKpSymmetric(2)),
+)
+
+for (name, problem, method) in runs
+    println("Integrating lotka_volterra_2d_singular with $(name) ...")
+    solution = integrate(problem, method)
+    save("lotka_volterra_2d_singular-$(name).pdf", plot_traces(solution, problem))
+end

--- a/examples/lotka_volterra_2d_singular.jl
+++ b/examples/lotka_volterra_2d_singular.jl
@@ -28,5 +28,5 @@ const runs = (
 for (name, problem, method) in runs
     println("Integrating lotka_volterra_2d_singular with $(name) ...")
     solution = integrate(problem, method)
-    save("lotka_volterra_2d_singular-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "lotka_volterra_2d_singular-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/lotka_volterra_2d_symmetric.jl
+++ b/examples/lotka_volterra_2d_symmetric.jl
@@ -1,0 +1,33 @@
+# Lotka-Volterra 2d with a symmetric Lagrangian: a survey of integrators
+#
+# Same system and same methods as `lotka_volterra_2d.jl`, but built from the symmetric
+# (gauge-fixed) Lagrangian rather than the standard one. The dynamics are identical; what differs
+# is the one-form ϑ the variational and SPARK integrators see, so this is the file to compare
+# against `lotka_volterra_2d.jl` when a projection behaves differently in one gauge than another.
+#
+# `LotkaVolterra2dSymmetric` has no plot extension of its own — only `LotkaVolterra2d` does — but
+# those plot functions are generic in the solution and the problem, so they are reused here.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.LotkaVolterra2dSymmetric
+
+import GeometricProblems.LotkaVolterra2d: plot_traces
+
+const timespan = (0.0, 10.0)
+const timestep = 0.01
+
+const runs = (
+    ("gauss2",                 odeproblem(;  timespan, timestep), Gauss(2)),
+    ("vprk-gauss2-midpoint",   iodeproblem(; timespan, timestep), MidpointProjection(VPRKGauss(2))),
+    ("vprk-gauss2-symmetric",  iodeproblem(; timespan, timestep), SymmetricProjection(VPRKGauss(2))),
+    ("vspark-glrk2-midpoint",  idaeproblem(; timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+    ("vspark-glrk2-symmetric", idaeproblem(; timespan, timestep), TableauVSPARKGLRKpSymmetric(2)),
+)
+
+for (name, problem, method) in runs
+    println("Integrating lotka_volterra_2d_symmetric with $(name) ...")
+    solution = integrate(problem, method)
+    save("lotka_volterra_2d_symmetric-$(name).pdf", plot_traces(solution, problem))
+end

--- a/examples/lotka_volterra_2d_symmetric.jl
+++ b/examples/lotka_volterra_2d_symmetric.jl
@@ -29,5 +29,5 @@ const runs = (
 for (name, problem, method) in runs
     println("Integrating lotka_volterra_2d_symmetric with $(name) ...")
     solution = integrate(problem, method)
-    save("lotka_volterra_2d_symmetric-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "lotka_volterra_2d_symmetric-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/lotka_volterra_3d.jl
+++ b/examples/lotka_volterra_3d.jl
@@ -1,0 +1,28 @@
+# Lotka-Volterra 3d: a survey of integrators
+#
+# The 3d system is a Poisson system with a Casimir as well as a Hamiltonian, and it is provided
+# only in its ODE form — there is no variational or DAE formulation here, so the survey is over
+# Runge-Kutta methods of increasing order. Writes one PDF per method next to this script, showing
+# the time traces together with the relative energy error.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricProblems.LotkaVolterra3d
+
+const timespan = (0.0, 10.0)
+const timestep = 0.01
+
+const runs = (
+    ("implicit-midpoint", ImplicitMidpoint()),
+    ("gauss1",            Gauss(1)),
+    ("gauss2",            Gauss(2)),
+    ("gauss8",            Gauss(8)),
+)
+
+const problem = odeproblem(; timespan, timestep)
+
+for (name, method) in runs
+    println("Integrating lotka_volterra_3d with $(name) ...")
+    solution = integrate(problem, method)
+    save("lotka_volterra_3d-$(name).pdf", plot_traces(solution, problem))
+end

--- a/examples/lotka_volterra_3d.jl
+++ b/examples/lotka_volterra_3d.jl
@@ -24,5 +24,5 @@ const problem = odeproblem(; timespan, timestep)
 for (name, method) in runs
     println("Integrating lotka_volterra_3d with $(name) ...")
     solution = integrate(problem, method)
-    save("lotka_volterra_3d-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "lotka_volterra_3d-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/lotka_volterra_4d.jl
+++ b/examples/lotka_volterra_4d.jl
@@ -1,0 +1,32 @@
+# Lotka-Volterra 4d: a survey of integrators
+#
+# The 4d system carries a degenerate Lagrangian, so it comes in a full set of formulations — ODE,
+# implicit ODE, Lagrangian ODE, and the corresponding DAEs — and the point of this example is that
+# the same trajectory can be reached through any of them. Writes one PDF per run next to this
+# script, showing the time traces together with the relative energy error.
+#
+# The pairings below are the ones exercised in `test/lotka_volterra_4d_tests.jl`.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.LotkaVolterra4d
+
+const timespan = (0.0, 10.0)
+const timestep = 0.01
+
+const runs = (
+    ("ode-gauss2",                 odeproblem(;  timespan, timestep), Gauss(2)),
+    ("iode-gauss2",                iodeproblem(; timespan, timestep), Gauss(2)),
+    ("lode-gauss2",                lodeproblem(; timespan, timestep), Gauss(2)),
+    ("iode-vprk-gauss2-midpoint",  iodeproblem(; timespan, timestep), MidpointProjection(VPRKGauss(2))),
+    ("iode-vprk-gauss2-symmetric", iodeproblem(; timespan, timestep), SymmetricProjection(VPRKGauss(2))),
+    ("idae-vspark-glrk2-midpoint", idaeproblem(; timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+    ("ldae-vspark-glrk2-midpoint", ldaeproblem(; timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+)
+
+for (name, problem, method) in runs
+    println("Integrating lotka_volterra_4d with $(name) ...")
+    solution = integrate(problem, method)
+    save("lotka_volterra_4d-$(name).pdf", plot_traces(solution, problem))
+end

--- a/examples/lotka_volterra_4d.jl
+++ b/examples/lotka_volterra_4d.jl
@@ -28,5 +28,5 @@ const runs = (
 for (name, problem, method) in runs
     println("Integrating lotka_volterra_4d with $(name) ...")
     solution = integrate(problem, method)
-    save("lotka_volterra_4d-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "lotka_volterra_4d-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/massless_charged_particle_2d.jl
+++ b/examples/massless_charged_particle_2d.jl
@@ -1,0 +1,32 @@
+# Massless charged particle in 2d: a survey of integrators
+#
+# The massless limit makes the Lagrangian degenerate by construction — the momentum is the magnetic
+# vector potential, not the velocity — so this is the problem the SPARK and variational families
+# were built for, and the one where the choice of projection is visible in the energy error.
+# Writes one PDF per method next to this script.
+#
+# The pairings below are the ones exercised in `test/massless_charged_particle_tests.jl`; note that
+# the SPARK method takes `idaeproblem_spark` rather than `idaeproblem`.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.MasslessChargedParticle
+
+# The module default is t ∈ [0, 1000] at Δt = 0.2, which is five thousand steps.
+const timespan = (0.0, 1000.0)
+const timestep = 0.2
+
+const runs = (
+    ("gauss8",                 odeproblem(;       timespan, timestep), Gauss(8)),
+    ("vspark-glrk2-midpoint",  idaeproblem(;      timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+    ("spark-glrk2",            idaeproblem_spark(; timespan, timestep), SPARKGLRK(2)),
+    ("vprk-gauss2-midpoint",   lodeproblem(;      timespan, timestep), MidpointProjection(VPRKGauss(2))),
+    ("slrk-lobatto-iiie2",     ldaeproblem(;      timespan, timestep), SLRKLobattoIIIE(2)),
+)
+
+for (name, problem, method) in runs
+    println("Integrating massless_charged_particle_2d with $(name) ...")
+    solution = integrate(problem, method)
+    save("massless_charged_particle_2d-$(name).pdf", plot_traces(solution, problem))
+end

--- a/examples/massless_charged_particle_2d.jl
+++ b/examples/massless_charged_particle_2d.jl
@@ -18,15 +18,15 @@ const timespan = (0.0, 1000.0)
 const timestep = 0.2
 
 const runs = (
-    ("gauss8",                 odeproblem(;       timespan, timestep), Gauss(8)),
-    ("vspark-glrk2-midpoint",  idaeproblem(;      timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
-    ("spark-glrk2",            idaeproblem_spark(; timespan, timestep), SPARKGLRK(2)),
-    ("vprk-gauss2-midpoint",   lodeproblem(;      timespan, timestep), MidpointProjection(VPRKGauss(2))),
-    ("slrk-lobatto-iiie2",     ldaeproblem(;      timespan, timestep), SLRKLobattoIIIE(2)),
+    ("gauss8",                odeproblem(;        timespan, timestep), Gauss(8)),
+    ("vspark-glrk2-midpoint", idaeproblem(;       timespan, timestep), TableauVSPARKGLRKpMidpoint(2)),
+    ("spark-glrk2",           idaeproblem_spark(; timespan, timestep), SPARKGLRK(2)),
+    ("vprk-gauss2-midpoint",  lodeproblem(;       timespan, timestep), MidpointProjection(VPRKGauss(2))),
+    ("slrk-lobatto-iiie2",    ldaeproblem(;       timespan, timestep), SLRKLobattoIIIE(2)),
 )
 
 for (name, problem, method) in runs
     println("Integrating massless_charged_particle_2d with $(name) ...")
     solution = integrate(problem, method)
-    save("massless_charged_particle_2d-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "massless_charged_particle_2d-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/point_vortices.jl
+++ b/examples/point_vortices.jl
@@ -25,5 +25,5 @@ const runs = (
 for (name, problem, method) in runs
     println("Integrating point_vortices with $(name) ...")
     solution = integrate(problem, method)
-    save("point_vortices-$(name).pdf", plot_traces(solution, problem))
+    save(joinpath(@__DIR__, "point_vortices-$(name).pdf"), plot_traces(solution, problem))
 end

--- a/examples/point_vortices_test.jl
+++ b/examples/point_vortices_test.jl
@@ -1,0 +1,29 @@
+# Point vortices: a survey of integrators
+#
+# Four interacting point vortices in the plane. The system is noncanonical and its Lagrangian is
+# degenerate, so as with the massless charged particle the interesting comparison is between plain
+# Runge-Kutta on the ODE form and the projected/SPARK methods on the implicit forms. Writes one
+# PDF per method next to this script, showing the time traces and the relative energy error.
+#
+# The pairings below are the ones exercised in `test/point_vortices_tests.jl`.
+
+using CairoMakie
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.PointVortices
+
+const timespan = (0.0, 10.0)
+const timestep = 0.01
+
+const runs = (
+    ("gauss2",                 odeproblem(;  timespan, timestep), Gauss(2)),
+    ("gauss8",                 odeproblem(;  timespan, timestep), Gauss(8)),
+    ("iode-gauss2",            iodeproblem(; timespan, timestep), Gauss(2)),
+    ("vspark-glrk2-symmetric", idaeproblem(; timespan, timestep), TableauVSPARKGLRKpSymmetric(2)),
+)
+
+for (name, problem, method) in runs
+    println("Integrating point_vortices with $(name) ...")
+    solution = integrate(problem, method)
+    save("point_vortices-$(name).pdf", plot_traces(solution, problem))
+end

--- a/ext/LotkaVolterra2dPoincareInvariants.jl
+++ b/ext/LotkaVolterra2dPoincareInvariants.jl
@@ -8,27 +8,24 @@ import GeometricProblems.LotkaVolterra2dSingular
 import GeometricProblems.LotkaVolterra2dSymmetric
 
 # `lotka_volterra_2d_equations.jl` is included into all four Lotka-Volterra 2d modules, so all four
-# export `ode_poincare_invariant_1st`/`iode_poincare_invariant_1st` and all four need a method here.
-# The bodies are identical up to the module they resolve their equations in, hence the loop.
+# declare these five names and all four need methods here. The bodies are identical up to the
+# module they resolve their equations in, hence the loop.
 #
-# `initial_conditions_loop` samples the loop `f_loop` parameterises — `f_loop` itself stays in the
-# parent module, since it is handed to the invariant as data — and `ode_loop`/`iode_loop` wrap it
-# into a problem. They are unexported scaffolding for the invariant and are used by nothing else,
-# which is why they live here rather than in `src/`.
+# `initial_conditions_loop` samples the loop the parent module's `f_loop` parameterises, and
+# `ode_loop`/`iode_loop` wrap it into a problem. All three are unexported scaffolding for the
+# invariants and are used by nothing else.
 #
-# The invariant methods and `ode_loop`/`iode_loop` are **dead**, and were dead under the
-# `Requires.@require` block this replaces:
-# `PoincareInvariant1st` was removed in PoincareInvariants 0.5.0, which moved the package from
-# SciML to JuliaGNI and reworked the interface (`FirstPoincareInvariant`/`FirstPI`, in-place forms
-# `form(out, t, z, p)`, and `compute!(pinv, integrate(PIEnsembleProblem(prob, pinv, init), method))`),
-# and `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode` are pre-0.7 constructor names — they are
-# `odeproblem`/`iodeproblem` now. Calling either method therefore throws `UndefVarError`.
+# Everything except `initial_conditions_loop` is **dead** and throws `UndefVarError` when called:
+# `PoincareInvariant1st` is not defined by PoincareInvariants 0.5 — the first invariant is
+# `FirstPoincareInvariant`/`FirstPI` there, forms are in-place (`form(out, t, z, p)`), and the entry
+# point is `compute!(pinv, integrate(PIEnsembleProblem(prob, pinv, init), method))` — and
+# `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode` are now `odeproblem`/`iodeproblem`.
 #
-# They are carried over unchanged on purpose. The Poincaré-invariant support needs a complete
-# makeover and the upstream interface is still being tuned, so 0.5 is not the target to write
-# against and a port done now would only be rewritten. What the move buys is visibility: an
-# extension is precompiled, so this file is at least loaded and parsed by CI, which is exactly what
-# `Requires` deferred to load time and nothing ever triggered.
+# The bodies are left unrepaired deliberately: the Poincaré-invariant support needs a makeover and
+# the PoincareInvariants interface is still being tuned, so 0.5 is not the interface to target.
+# Nothing exercises this file yet — an extension is precompiled only in an environment that has its
+# trigger package, and `test/Project.toml` does not list PoincareInvariants. Adding it there is what
+# would put this code in front of CI.
 for M in (:LotkaVolterra2d, :LotkaVolterra2dGauge, :LotkaVolterra2dSingular, :LotkaVolterra2dSymmetric)
     @eval begin
         function $M.initial_conditions_loop(n)

--- a/ext/LotkaVolterra2dPoincareInvariants.jl
+++ b/ext/LotkaVolterra2dPoincareInvariants.jl
@@ -8,14 +8,14 @@ import GeometricProblems.LotkaVolterra2dSingular
 import GeometricProblems.LotkaVolterra2dSymmetric
 
 # `lotka_volterra_2d_equations.jl` is included into all four Lotka-Volterra 2d modules, so all four
-# declare these five names and all four need methods here. The bodies are identical up to the
+# declare these four names and all four need methods here. The bodies are identical up to the
 # module they resolve their equations in, hence the loop.
 #
-# `initial_conditions_loop` samples the loop the parent module's `f_loop` parameterises, and
-# `ode_loop`/`iode_loop` wrap it into a problem. All three are unexported scaffolding for the
-# invariants and are used by nothing else.
+# `ode_loop`/`iode_loop` wrap the parent module's `initial_conditions_loop` into a problem; they are
+# unexported scaffolding for the invariants and are used by nothing else. `f_loop` and
+# `initial_conditions_loop` themselves stay in `src/`, since they need nothing from this package.
 #
-# Everything except `initial_conditions_loop` is **dead** and throws `UndefVarError` when called:
+# All four are **dead** and throw `UndefVarError` when called:
 # `PoincareInvariant1st` is not defined by PoincareInvariants 0.5 — the first invariant is
 # `FirstPoincareInvariant`/`FirstPI` there, forms are in-place (`form(out, t, z, p)`), and the entry
 # point is `compute!(pinv, integrate(PIEnsembleProblem(prob, pinv, init), method))` — and
@@ -23,21 +23,11 @@ import GeometricProblems.LotkaVolterra2dSymmetric
 #
 # The bodies are left unrepaired deliberately: the Poincaré-invariant support needs a makeover and
 # the PoincareInvariants interface is still being tuned, so 0.5 is not the interface to target.
-# Nothing exercises this file yet — an extension is precompiled only in an environment that has its
-# trigger package, and `test/Project.toml` does not list PoincareInvariants. Adding it there is what
-# would put this code in front of CI.
+# What *is* exercised is that this file loads: `test/Project.toml` lists PoincareInvariants, so the
+# extension is precompiled during the test run and `test/poincare_invariants_tests.jl` asserts that
+# it resolved and attached its methods to all four modules.
 for M in (:LotkaVolterra2d, :LotkaVolterra2dGauge, :LotkaVolterra2dSingular, :LotkaVolterra2dSymmetric)
     @eval begin
-        function $M.initial_conditions_loop(n)
-            q₀ = zeros(2, n)
-
-            for i in axes(q₀, 2)
-                q₀[:, i] .= $M.f_loop(i, n)
-            end
-
-            return q₀
-        end
-
         function $M.ode_loop(n)
             $M.lotka_volterra_2d_ode($M.initial_conditions_loop(n))
         end

--- a/ext/LotkaVolterra2dPoincareInvariants.jl
+++ b/ext/LotkaVolterra2dPoincareInvariants.jl
@@ -11,7 +11,13 @@ import GeometricProblems.LotkaVolterra2dSymmetric
 # export `ode_poincare_invariant_1st`/`iode_poincare_invariant_1st` and all four need a method here.
 # The bodies are identical up to the module they resolve their equations in, hence the loop.
 #
-# These methods are **dead**, and were dead under the `Requires.@require` block this replaces:
+# `initial_conditions_loop` samples the loop `f_loop` parameterises — `f_loop` itself stays in the
+# parent module, since it is handed to the invariant as data — and `ode_loop`/`iode_loop` wrap it
+# into a problem. They are unexported scaffolding for the invariant and are used by nothing else,
+# which is why they live here rather than in `src/`.
+#
+# The invariant methods and `ode_loop`/`iode_loop` are **dead**, and were dead under the
+# `Requires.@require` block this replaces:
 # `PoincareInvariant1st` was removed in PoincareInvariants 0.5.0, which moved the package from
 # SciML to JuliaGNI and reworked the interface (`FirstPoincareInvariant`/`FirstPI`, in-place forms
 # `form(out, t, z, p)`, and `compute!(pinv, integrate(PIEnsembleProblem(prob, pinv, init), method))`),
@@ -25,6 +31,24 @@ import GeometricProblems.LotkaVolterra2dSymmetric
 # `Requires` deferred to load time and nothing ever triggered.
 for M in (:LotkaVolterra2d, :LotkaVolterra2dGauge, :LotkaVolterra2dSingular, :LotkaVolterra2dSymmetric)
     @eval begin
+        function $M.initial_conditions_loop(n)
+            q₀ = zeros(2, n)
+
+            for i in axes(q₀, 2)
+                q₀[:, i] .= $M.f_loop(i, n)
+            end
+
+            return q₀
+        end
+
+        function $M.ode_loop(n)
+            $M.lotka_volterra_2d_ode($M.initial_conditions_loop(n))
+        end
+
+        function $M.iode_loop(n)
+            $M.lotka_volterra_2d_iode($M.initial_conditions_loop(n))
+        end
+
         function $M.ode_poincare_invariant_1st(timestep, nloop, ntime, nsave, DT = Float64)
             PoincareInvariant1st($M.lotka_volterra_2d_ode, $M.f_loop, $M.ϑ,
                 timestep, 2, nloop, ntime, nsave, DT)

--- a/ext/LotkaVolterra2dPoincareInvariants.jl
+++ b/ext/LotkaVolterra2dPoincareInvariants.jl
@@ -1,0 +1,40 @@
+module LotkaVolterra2dPoincareInvariants
+
+using PoincareInvariants
+
+import GeometricProblems.LotkaVolterra2d
+import GeometricProblems.LotkaVolterra2dGauge
+import GeometricProblems.LotkaVolterra2dSingular
+import GeometricProblems.LotkaVolterra2dSymmetric
+
+# `lotka_volterra_2d_equations.jl` is included into all four Lotka-Volterra 2d modules, so all four
+# export `ode_poincare_invariant_1st`/`iode_poincare_invariant_1st` and all four need a method here.
+# The bodies are identical up to the module they resolve their equations in, hence the loop.
+#
+# These methods are **dead**, and were dead under the `Requires.@require` block this replaces:
+# `PoincareInvariant1st` was removed in PoincareInvariants 0.5.0, which moved the package from
+# SciML to JuliaGNI and reworked the interface (`FirstPoincareInvariant`/`FirstPI`, in-place forms
+# `form(out, t, z, p)`, and `compute!(pinv, integrate(PIEnsembleProblem(prob, pinv, init), method))`),
+# and `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode` are pre-0.7 constructor names — they are
+# `odeproblem`/`iodeproblem` now. Calling either method therefore throws `UndefVarError`.
+#
+# They are carried over unchanged on purpose. The Poincaré-invariant support needs a complete
+# makeover and the upstream interface is still being tuned, so 0.5 is not the target to write
+# against and a port done now would only be rewritten. What the move buys is visibility: an
+# extension is precompiled, so this file is at least loaded and parsed by CI, which is exactly what
+# `Requires` deferred to load time and nothing ever triggered.
+for M in (:LotkaVolterra2d, :LotkaVolterra2dGauge, :LotkaVolterra2dSingular, :LotkaVolterra2dSymmetric)
+    @eval begin
+        function $M.ode_poincare_invariant_1st(timestep, nloop, ntime, nsave, DT = Float64)
+            PoincareInvariant1st($M.lotka_volterra_2d_ode, $M.f_loop, $M.ϑ,
+                timestep, 2, nloop, ntime, nsave, DT)
+        end
+
+        function $M.iode_poincare_invariant_1st(timestep, nloop, ntime, nsave, DT = Float64)
+            PoincareInvariant1st($M.lotka_volterra_2d_iode, $M.f_loop, $M.ϑ,
+                timestep, 2, nloop, ntime, nsave, DT)
+        end
+    end
+end
+
+end

--- a/src/lotka_volterra_2d_equations.jl
+++ b/src/lotka_volterra_2d_equations.jl
@@ -1,7 +1,6 @@
 
 using GeometricEquations
 using GeometricSolutions
-using Requires
 
 export odeproblem,  daeproblem,
        podeproblem, pdaeproblem,
@@ -165,16 +164,15 @@ function iode_loop(n)
 end
 
 
-function __init__()
-    @require PoincareInvariants = "26663084-47d3-540f-bd97-40ca743aafa4" begin
-
-        function ode_poincare_invariant_1st(timestep, nloop, ntime, nsave, DT=Float64)
-            PoincareInvariant1st(lotka_volterra_2d_ode, f_loop, ϑ, timestep, 2, nloop, ntime, nsave, DT)
-        end
-
-        function iode_poincare_invariant_1st(timestep, nloop, ntime, nsave, DT=Float64)
-            PoincareInvariant1st(lotka_volterra_2d_iode, f_loop, ϑ, timestep, 2, nloop, ntime, nsave, DT)
-        end
-
-    end
-end
+# The first Poincaré invariant is implemented in the `LotkaVolterra2dPoincareInvariants` extension
+# (loaded with PoincareInvariants), in the same shape as the `*Plots` extensions.
+#
+# Both methods are **dead** and were dead before the move: their bodies call `PoincareInvariant1st`,
+# removed in PoincareInvariants 0.5.0, on `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which
+# are pre-0.7 constructor names (`odeproblem`/`iodeproblem` today). They are carried over unchanged
+# rather than repaired: the whole Poincaré-invariant integration is slated for a makeover, and the
+# PoincareInvariants interface is still being tuned, so 0.5 is not the target to write against.
+# Moving them out of `Requires.@require` and into an extension at least puts them where
+# precompilation — and therefore CI — can see them.
+function ode_poincare_invariant_1st end
+function iode_poincare_invariant_1st end

--- a/src/lotka_volterra_2d_equations.jl
+++ b/src/lotka_volterra_2d_equations.jl
@@ -147,18 +147,14 @@ end
 # The first Poincaré invariant, and the loop scaffolding it is built on, are implemented in the
 # `LotkaVolterra2dPoincareInvariants` extension (loaded with PoincareInvariants), in the same shape
 # as the `*Plots` extensions. Only `f_loop` above stays here: it parameterises the loop in phase
-# space and is handed to the invariant as data, so both the extension's `initial_conditions_loop`
-# and its invariant methods read it off the module.
+# space and is read off the module by both the extension's `initial_conditions_loop` and its
+# invariant methods.
 #
-# `ode_poincare_invariant_1st`, `iode_poincare_invariant_1st`, `ode_loop` and `iode_loop` are
-# **dead**, and were dead before the move: they call `PoincareInvariant1st`, removed in
-# PoincareInvariants 0.5.0, and `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are pre-0.7
-# constructor names (`odeproblem`/`iodeproblem` today). `initial_conditions_loop` does work, but
-# nothing outside this cluster uses it. All five are carried over unchanged rather than repaired:
-# the whole Poincaré-invariant integration is slated for a makeover, and the PoincareInvariants
-# interface is still being tuned, so 0.5 is not the target to write against. Moving them out of
-# `Requires.@require` and into an extension at least puts them where precompilation — and therefore
-# CI — can see them.
+# Everything except `initial_conditions_loop` is **dead** and throws `UndefVarError` when called:
+# the invariants need `PoincareInvariant1st`, which PoincareInvariants 0.5 does not define, and the
+# two `*_loop` wrappers call `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are now
+# `odeproblem`/`iodeproblem`. The bodies await a makeover of the Poincaré-invariant support; the
+# extension has the details.
 function initial_conditions_loop end
 function ode_loop end
 function iode_loop end

--- a/src/lotka_volterra_2d_equations.jl
+++ b/src/lotka_volterra_2d_equations.jl
@@ -45,6 +45,20 @@ function f_loop(i, n)
    f_loop(i/n)
 end
 
+# Samples the loop `f_loop` parameterises at `n` equidistant points. Together with `f_loop` this is
+# the live half of the Poincaré-invariant scaffolding, and it depends on nothing optional, so it
+# stays here rather than moving into the extension with the invariants themselves.
+function initial_conditions_loop(n)
+   q₀ = zeros(2, n)
+
+   for i in axes(q₀,2)
+       q₀[:,i] .= f_loop(i, n)
+   end
+
+   return q₀
+end
+
+
 compute_energy_error(t, q, params) = compute_invariant_error(t, q, params, hamiltonian)
 
 
@@ -144,18 +158,17 @@ function iodeproblem_dg(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPA
 end
 
 
-# The first Poincaré invariant, and the loop scaffolding it is built on, are implemented in the
+# The first Poincaré invariant, and the two problem wrappers built on it, are implemented in the
 # `LotkaVolterra2dPoincareInvariants` extension (loaded with PoincareInvariants), in the same shape
-# as the `*Plots` extensions. Only `f_loop` above stays here: it parameterises the loop in phase
-# space and is read off the module by both the extension's `initial_conditions_loop` and its
-# invariant methods.
+# as the `*Plots` extensions. `f_loop` and `initial_conditions_loop` above stay here instead: they
+# parameterise and sample the loop in phase space, need nothing optional to do it, and are read off
+# the module by the extension.
 #
-# Everything except `initial_conditions_loop` is **dead** and throws `UndefVarError` when called:
-# the invariants need `PoincareInvariant1st`, which PoincareInvariants 0.5 does not define, and the
-# two `*_loop` wrappers call `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are now
+# All four names below are **dead** and throw `UndefVarError` when called: the invariants need
+# `PoincareInvariant1st`, which PoincareInvariants 0.5 does not define, and the two `*_loop`
+# wrappers call `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are now
 # `odeproblem`/`iodeproblem`. The bodies await a makeover of the Poincaré-invariant support; the
 # extension has the details.
-function initial_conditions_loop end
 function ode_loop end
 function iode_loop end
 function ode_poincare_invariant_1st end

--- a/src/lotka_volterra_2d_equations.jl
+++ b/src/lotka_volterra_2d_equations.jl
@@ -45,17 +45,6 @@ function f_loop(i, n)
    f_loop(i/n)
 end
 
-function initial_conditions_loop(n)
-   q₀ = zeros(2, n)
-
-   for i in axes(q₀,2)
-       q₀[:,i] .= f_loop(i, n)
-   end
-
-   return q₀
-end
-
-
 compute_energy_error(t, q, params) = compute_invariant_error(t, q, params, hamiltonian)
 
 
@@ -155,24 +144,23 @@ function iodeproblem_dg(q₀=q₀, p₀=ϑ(t₀, q₀); timespan=DEFAULT_TIMESPA
 end
 
 
-function ode_loop(n)
-   lotka_volterra_2d_ode(initial_conditions_loop(n))
-end
-
-function iode_loop(n)
-   lotka_volterra_2d_iode(initial_conditions_loop(n))
-end
-
-
-# The first Poincaré invariant is implemented in the `LotkaVolterra2dPoincareInvariants` extension
-# (loaded with PoincareInvariants), in the same shape as the `*Plots` extensions.
+# The first Poincaré invariant, and the loop scaffolding it is built on, are implemented in the
+# `LotkaVolterra2dPoincareInvariants` extension (loaded with PoincareInvariants), in the same shape
+# as the `*Plots` extensions. Only `f_loop` above stays here: it parameterises the loop in phase
+# space and is handed to the invariant as data, so both the extension's `initial_conditions_loop`
+# and its invariant methods read it off the module.
 #
-# Both methods are **dead** and were dead before the move: their bodies call `PoincareInvariant1st`,
-# removed in PoincareInvariants 0.5.0, on `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which
-# are pre-0.7 constructor names (`odeproblem`/`iodeproblem` today). They are carried over unchanged
-# rather than repaired: the whole Poincaré-invariant integration is slated for a makeover, and the
-# PoincareInvariants interface is still being tuned, so 0.5 is not the target to write against.
-# Moving them out of `Requires.@require` and into an extension at least puts them where
-# precompilation — and therefore CI — can see them.
+# `ode_poincare_invariant_1st`, `iode_poincare_invariant_1st`, `ode_loop` and `iode_loop` are
+# **dead**, and were dead before the move: they call `PoincareInvariant1st`, removed in
+# PoincareInvariants 0.5.0, and `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are pre-0.7
+# constructor names (`odeproblem`/`iodeproblem` today). `initial_conditions_loop` does work, but
+# nothing outside this cluster uses it. All five are carried over unchanged rather than repaired:
+# the whole Poincaré-invariant integration is slated for a makeover, and the PoincareInvariants
+# interface is still being tuned, so 0.5 is not the target to write against. Moving them out of
+# `Requires.@require` and into an extension at least puts them where precompilation — and therefore
+# CI — can see them.
+function initial_conditions_loop end
+function ode_loop end
+function iode_loop end
 function ode_poincare_invariant_1st end
 function iode_poincare_invariant_1st end

--- a/src/three_body_problem.jl
+++ b/src/three_body_problem.jl
@@ -97,18 +97,12 @@ module ThreeBody
     ``\Delta{}t = 0.5, 0.05, 0.01, 0.005, 0.001`` the default Newton method with a backtracking line
     search commits an energy error of 19, 15, 36, 399 and 249, and the trust-region `DogLeg` solver
     one of 9, 45, 12, 1615 and ``2.2 \times 10^6`` — with the two ending up 0.6, 3.8, 5.0, 50 and
-    1209 apart in ``q``. Neither is quieter than the other about it: they emit 5, 9, 4, 4, 4 and
-    6, 1, 1, 5, 6 solver messages respectively. Since neither solver can integrate the collision and
-    neither is systematically better behaved, the default Newton solver is kept; on problems that
-    *are* solvable the two agree bit for bit.
-
-    Under SimpleSolvers 0.9 the same measurement gave 596, 1346, 390, 321 and 361 messages for
-    Newton against 1–2 for `DogLeg`, and this paragraph existed to explain that the trust region was
-    merely quieter about the same failure. That asymmetry was itself an artefact: 0.10 caps repeated
-    reports with `maxlog` and stops a stagnating solve after `max_stalls` rather than letting it
-    spin to `max_iterations`, so the message count now measures how a failure is *reported*, not how
-    badly it fails. The energy error is the quantity to read, and it says the same thing the old
-    counts were being used to argue.
+    1209 apart in ``q``. Neither is quieter than the other about it — they emit 5, 9, 4, 4, 4 and
+    6, 1, 1, 5, 6 solver messages respectively — though the count is not the thing to compare on:
+    repeated reports are capped by `maxlog` and a stagnating solve stops after `max_stalls`, so it
+    measures how a failure is *reported* rather than how badly it fails. Since neither solver can
+    integrate the collision and neither is systematically better behaved, the default Newton solver
+    is kept; on problems that *are* solvable the two agree bit for bit.
     """
     const DEFAULT_TIMESTEP = figure_eight_period / 400
 

--- a/src/three_body_problem.jl
+++ b/src/three_body_problem.jl
@@ -93,12 +93,22 @@ module ThreeBody
     ``1.3 \times 10^{-3}``; `Gauss(2)` reaches ``3 \times 10^{-15}`` and ``1.3 \times 10^{-7}``.
 
     Neither this nor any other step size makes `sympnets_initial_condition` integrable past its
-    collision, and neither does exchanging the nonlinear solver: over ``t \in [0, 1]`` the default
-    Newton method with a backtracking line search emits 596, 1346, 390, 321 and 361 warnings for
-    ``\Delta{}t = 0.5, 0.05, 0.01, 0.005, 0.001``, while the trust-region `DogLeg` solver emits 1–2
-    — but commits an energy error of 12 to 45 either way, and the two disagree on where the bodies
-    end up. The trust region is merely quieter about the same failure, so the default Newton solver
-    is kept; on problems that *are* solvable the two agree bit for bit.
+    collision, and neither does exchanging the nonlinear solver. Over ``t \in [0, 1]`` at
+    ``\Delta{}t = 0.5, 0.05, 0.01, 0.005, 0.001`` the default Newton method with a backtracking line
+    search commits an energy error of 19, 15, 36, 399 and 249, and the trust-region `DogLeg` solver
+    one of 9, 45, 12, 1615 and ``2.2 \times 10^6`` — with the two ending up 0.6, 3.8, 5.0, 50 and
+    1209 apart in ``q``. Neither is quieter than the other about it: they emit 5, 9, 4, 4, 4 and
+    6, 1, 1, 5, 6 solver messages respectively. Since neither solver can integrate the collision and
+    neither is systematically better behaved, the default Newton solver is kept; on problems that
+    *are* solvable the two agree bit for bit.
+
+    Under SimpleSolvers 0.9 the same measurement gave 596, 1346, 390, 321 and 361 messages for
+    Newton against 1–2 for `DogLeg`, and this paragraph existed to explain that the trust region was
+    merely quieter about the same failure. That asymmetry was itself an artefact: 0.10 caps repeated
+    reports with `maxlog` and stops a stagnating solve after `max_stalls` rather than letting it
+    spin to `max_iterations`, so the message count now measures how a failure is *reported*, not how
+    badly it fails. The energy error is the quantity to read, and it says the same thing the old
+    counts were being used to argue.
     """
     const DEFAULT_TIMESTEP = figure_eight_period / 400
 

--- a/src/three_body_problem.jl
+++ b/src/three_body_problem.jl
@@ -100,9 +100,11 @@ module ThreeBody
     1209 apart in ``q``. Neither is quieter than the other about it — they emit 5, 9, 4, 4, 4 and
     6, 1, 1, 5, 6 solver messages respectively — though the count is not the thing to compare on:
     repeated reports are capped by `maxlog` and a stagnating solve stops after `max_stalls`, so it
-    measures how a failure is *reported* rather than how badly it fails. Since neither solver can
-    integrate the collision and neither is systematically better behaved, the default Newton solver
-    is kept; on problems that *are* solvable the two agree bit for bit.
+    measures how a failure is *reported* rather than how badly it fails. The energy error is, and on
+    it `DogLeg` is not an improvement but a regression: it is worse at the two finest step sizes by
+    factors of 4 and ``9 \times 10^3``, and better nowhere by more than a factor of 3. Since neither
+    solver can integrate the collision and the trust region is the worse of the two where it differs,
+    the default Newton solver is kept; on problems that *are* solvable the two agree bit for bit.
     """
     const DEFAULT_TIMESTEP = figure_eight_period / 400
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,6 +7,7 @@ GeometricProblems = "18cb22b4-ad41-5c80-9c5f-710df63fbdc9"
 GeometricSolutions = "7843afe4-64f4-4df4-9231-049495c56661"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+PoincareInvariants = "26663084-47d3-540f-bd97-40ca743aafa4"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
@@ -17,6 +18,10 @@ GeometricProblems = {path = ".."}
 # GeometricIntegrators is a test-only dependency, so its bound belongs here, where it is
 # resolved, and not in the root project. 0.17 is what pulls in SimpleSolvers 0.10 and
 # GeometricIntegratorsBase 0.5.1; everything below 0.17 pins SimpleSolvers to 0.9.
+#
+# PoincareInvariants is here only as an extension trigger: it is what makes Pkg precompile
+# `LotkaVolterra2dPoincareInvariants` during the test run, so that a syntax or resolution error in
+# the extension fails CI. See `poincare_invariants_tests.jl`.
 [compat]
 CairoMakie = "0.15"
 ForwardDiff = "0.10, 1"
@@ -25,6 +30,7 @@ GeometricIntegrators = "0.17"
 GeometricSolutions = "0.6.5"
 LinearAlgebra = "1"
 Logging = "1"
+PoincareInvariants = "0.4, 0.5"
 SafeTestsets = "0.1"
 Test = "1"
 Unicode = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,3 +13,19 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [sources]
 GeometricProblems = {path = ".."}
+
+# GeometricIntegrators is a test-only dependency, so its bound belongs here, where it is
+# resolved, and not in the root project. 0.17 is what pulls in SimpleSolvers 0.10 and
+# GeometricIntegratorsBase 0.5.1; everything below 0.17 pins SimpleSolvers to 0.9.
+[compat]
+CairoMakie = "0.15"
+ForwardDiff = "0.10, 1"
+GeometricEquations = "0.21"
+GeometricIntegrators = "0.17"
+GeometricSolutions = "0.6.5"
+LinearAlgebra = "1"
+Logging = "1"
+SafeTestsets = "0.1"
+Test = "1"
+Unicode = "1"
+julia = "1.10"

--- a/test/coupled_harmonic_oscillator_tests.jl
+++ b/test/coupled_harmonic_oscillator_tests.jl
@@ -2,6 +2,8 @@ using GeometricIntegrators: ImplicitMidpoint, integrate
 import GeometricProblems.CoupledHarmonicOscillator as cho
 using Test
 
+include("integrate_quietly.jl")
+
 
 q₀_vec = [cho.q₀ .+ α for α in 0. : .4 : .4]
 p₀_vec = [cho.p₀ .+ α for α in 0. : .4 : .4]
@@ -10,7 +12,7 @@ p₀_vec = [cho.p₀ .+ α for α in 0. : .4 : .4]
 epr = cho.hodeensemble(q₀_vec, p₀_vec)
 
 # ensemble solution
-esol = integrate(epr, ImplicitMidpoint())
+esol = integrate_quietly(epr, ImplicitMidpoint())
 
 @test esol.s[2].q.d.parent ≉ esol.s[1].q.d.parent
 
@@ -23,6 +25,6 @@ end
 epr = cho.hodeensemble(; parameters = [_params(i) for i in 0:1])
 
 # ensemble solution
-esol = integrate(epr, ImplicitMidpoint())
+esol = integrate_quietly(epr, ImplicitMidpoint())
 
 @test esol.s[2].q.d.parent ≉ esol.s[1].q.d.parent

--- a/test/eulerlagrange_ensembles_tests.jl
+++ b/test/eulerlagrange_ensembles_tests.jl
@@ -1,6 +1,7 @@
-using GeometricIntegrators: ImplicitMidpoint, integrate
-using Logging: Warn, with_logger
+using GeometricIntegrators: ImplicitMidpoint
 using Test
+
+include("integrate_quietly.jl")
 
 # Tests for issue #64: parameter-varying (and initial-condition-varying) ensembles for the
 # EulerLagrange-generated HODE/LODE problems. These complement the existing ensemble tests
@@ -14,23 +15,6 @@ import GeometricProblems.MathewsLakshmananOscillator as ml
 import GeometricProblems.DoublePendulum as dp
 import GeometricProblems.ThreeBody as tb
 import GeometricProblems.LinearWave as lw
-
-# Integrate and assert that the nonlinear solver stayed quiet. An implicit step whose Newton
-# iteration cannot reach a root — as every ThreeBody step used to do when the default initial
-# condition was still a member of the collisional `initial_conditions` grid, see
-# `ThreeBody.sympnets_initial_condition` — still returns a solution, so it fails no assertion here
-# while flooding the log with line-search warnings. Warnings are attributed by originating module
-# rather than caught with `@test_nowarn`, both to ignore the unrelated `GeometricEquations` warning
-# about single-sample ensembles and because SimpleSolvers is only an indirect dependency (via
-# GeometricIntegrators), so it must not be imported.
-function integrate_quietly(problem, method)
-    logger = TestLogger(min_level = Warn)
-    solution = with_logger(() -> integrate(problem, method), logger)
-    # Assert on the distinct messages rather than their count, so that a failure reports what the
-    # solver actually complained about.
-    @test isempty(unique(l.message for l in logger.logs if nameof(l._module) === :SimpleSolvers))
-    solution
-end
 
 # Perturb a single parameter of the module's default parameter set.
 _perturbed(M, field, δ) = merge(M.default_parameters(),

--- a/test/integrate_quietly.jl
+++ b/test/integrate_quietly.jl
@@ -1,5 +1,5 @@
 using GeometricIntegrators: integrate
-using Logging: Warn, with_logger
+using Logging: Warn, current_logger, with_logger, handle_message, min_enabled_level, shouldlog
 using Test
 
 # Integrate, and assert that the nonlinear solver stayed quiet.
@@ -13,13 +13,40 @@ using Test
 # ignore the unrelated `GeometricEquations` warning about single-sample ensembles and because
 # SimpleSolvers is only an indirect dependency (via GeometricIntegrators), so it must not be
 # imported. The `:SimpleSolvers` symbol is therefore load-bearing: should those messages move to
-# another module, this filter matches nothing and the assertion passes vacuously rather than
-# failing.
-function integrate_quietly(problem, method)
+# another module, this filter would match nothing and all 33 assertions built on it would pass
+# vacuously rather than failing. The positive control in `three_body_tests.jl` is what keeps that
+# from going unnoticed — it integrates a case known to complain and asserts the filter still
+# catches it.
+
+const SIMPLESOLVERS = :SimpleSolvers
+
+# Integrate while capturing the log, and return the distinct SimpleSolvers messages alongside the
+# solution. Records from every other module are forwarded to the enclosing logger rather than
+# swallowed, so that unrelated warnings stay visible and stay catchable by an enclosing
+# `@test_nowarn`.
+function integrate_capturing_messages(problem, method)
     logger = TestLogger(min_level = Warn)
     solution = with_logger(() -> integrate(problem, method), logger)
+
+    outer = current_logger()
+    for l in logger.logs
+        nameof(l._module) === SIMPLESOLVERS && continue
+        min_enabled_level(outer) <= l.level || continue
+        shouldlog(outer, l.level, l._module, l.group, l.id) || continue
+        handle_message(outer, l.level, l.message, l._module, l.group, l.id, l.file, l.line;
+            l.kwargs...)
+    end
+
+    unique(l.message for l in logger.logs if nameof(l._module) === SIMPLESOLVERS), solution
+end
+
+"Distinct SimpleSolvers messages emitted while integrating `problem` with `method`."
+simplesolvers_messages(problem, method) = first(integrate_capturing_messages(problem, method))
+
+function integrate_quietly(problem, method)
+    messages, solution = integrate_capturing_messages(problem, method)
     # Assert on the distinct messages rather than their count, so that a failure reports what the
     # solver actually complained about.
-    @test isempty(unique(l.message for l in logger.logs if nameof(l._module) === :SimpleSolvers))
+    @test isempty(messages)
     solution
 end

--- a/test/integrate_quietly.jl
+++ b/test/integrate_quietly.jl
@@ -2,23 +2,19 @@ using GeometricIntegrators: integrate
 using Logging: Warn, with_logger
 using Test
 
-# Integrate and assert that the nonlinear solver stayed quiet. An implicit step whose Newton
-# iteration cannot reach a root — as every `ThreeBody` step used to do when the default initial
-# condition was still a member of the collisional `initial_conditions` grid, see
-# `ThreeBody.sympnets_initial_condition` — still returns a solution, so it fails no assertion here
-# while flooding the log with line-search warnings.
+# Integrate, and assert that the nonlinear solver stayed quiet.
+#
+# An implicit step whose Newton iteration cannot reach a root still returns a solution rather than
+# throwing — `ThreeBody.sympnets_initial_condition` is such a case, since it ends in a collision —
+# so on its own it fails no assertion while filling the log with line-search warnings. Asserting
+# silence turns that into a test failure; `verbosity = 0` would only hide it.
 #
 # Warnings are attributed by originating module rather than caught with `@test_nowarn`, both to
 # ignore the unrelated `GeometricEquations` warning about single-sample ensembles and because
 # SimpleSolvers is only an indirect dependency (via GeometricIntegrators), so it must not be
-# imported. The `:SimpleSolvers` symbol is therefore load-bearing: should those messages ever move
-# to another module, this filter matches nothing and the assertion passes vacuously rather than
-# failing. `test/runtests.jl`'s suite-wide count is the backstop for that.
-#
-# This asserts silence rather than suppressing it, which is only possible from SimpleSolvers 0.10
-# on: before that a line search built its own `Options` and never saw the solver's `verbosity`, so
-# a converging solve reported its round-off floor as a warning and which orbits tripped it depended
-# on platform floating-point details.
+# imported. The `:SimpleSolvers` symbol is therefore load-bearing: should those messages move to
+# another module, this filter matches nothing and the assertion passes vacuously rather than
+# failing.
 function integrate_quietly(problem, method)
     logger = TestLogger(min_level = Warn)
     solution = with_logger(() -> integrate(problem, method), logger)

--- a/test/integrate_quietly.jl
+++ b/test/integrate_quietly.jl
@@ -1,0 +1,29 @@
+using GeometricIntegrators: integrate
+using Logging: Warn, with_logger
+using Test
+
+# Integrate and assert that the nonlinear solver stayed quiet. An implicit step whose Newton
+# iteration cannot reach a root — as every `ThreeBody` step used to do when the default initial
+# condition was still a member of the collisional `initial_conditions` grid, see
+# `ThreeBody.sympnets_initial_condition` — still returns a solution, so it fails no assertion here
+# while flooding the log with line-search warnings.
+#
+# Warnings are attributed by originating module rather than caught with `@test_nowarn`, both to
+# ignore the unrelated `GeometricEquations` warning about single-sample ensembles and because
+# SimpleSolvers is only an indirect dependency (via GeometricIntegrators), so it must not be
+# imported. The `:SimpleSolvers` symbol is therefore load-bearing: should those messages ever move
+# to another module, this filter matches nothing and the assertion passes vacuously rather than
+# failing. `test/runtests.jl`'s suite-wide count is the backstop for that.
+#
+# This asserts silence rather than suppressing it, which is only possible from SimpleSolvers 0.10
+# on: before that a line search built its own `Options` and never saw the solver's `verbosity`, so
+# a converging solve reported its round-off floor as a warning and which orbits tripped it depended
+# on platform floating-point details.
+function integrate_quietly(problem, method)
+    logger = TestLogger(min_level = Warn)
+    solution = with_logger(() -> integrate(problem, method), logger)
+    # Assert on the distinct messages rather than their count, so that a failure reports what the
+    # solver actually complained about.
+    @test isempty(unique(l.message for l in logger.logs if nameof(l._module) === :SimpleSolvers))
+    solution
+end

--- a/test/linear_wave_tests.jl
+++ b/test/linear_wave_tests.jl
@@ -5,6 +5,8 @@ using GeometricSolutions
 using LinearAlgebra
 using Test
 
+include("integrate_quietly.jl")
+
 const LW = LinearWave
 
 # Regression test for the linear wave equation. Previously `lodeproblem` called a lowercase
@@ -144,8 +146,8 @@ end
     hode = hodeproblem(N; timespan = timespan, timestep = timestep)
     lode = lodeproblem(N; timespan = timespan, timestep = timestep)
 
-    hode_sol = integrate(hode, ImplicitMidpoint())
-    lode_sol = integrate(lode, ImplicitMidpoint())
+    hode_sol = integrate_quietly(hode, ImplicitMidpoint())
+    lode_sol = integrate_quietly(lode, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1E-12
     @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1E-11
@@ -155,8 +157,8 @@ end
     hode_sym = hodeproblem(N; timespan = timespan, timestep = timestep, symbolic = true)
     lode_sym = lodeproblem(N; timespan = timespan, timestep = timestep, symbolic = true)
 
-    hode_sym_sol = integrate(hode_sym, ImplicitMidpoint())
-    lode_sym_sol = integrate(lode_sym, ImplicitMidpoint())
+    hode_sym_sol = integrate_quietly(hode_sym, ImplicitMidpoint())
+    lode_sym_sol = integrate_quietly(lode_sym, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, hode_sym_sol.q) < 1E-12
     @test relative_maximum_error(hode_sol.p, hode_sym_sol.p) < 1E-11

--- a/test/outer_solar_system_tests.jl
+++ b/test/outer_solar_system_tests.jl
@@ -3,6 +3,8 @@ using GeometricIntegrators
 using GeometricProblems.OuterSolarSystem
 using GeometricSolutions
 
+include("integrate_quietly.jl")
+
 const OSS = OuterSolarSystem
 
 @testset "$(rpad("Outer Solar System",80))" begin
@@ -14,8 +16,8 @@ const OSS = OuterSolarSystem
     hode = @test_nowarn hodeproblem(timespan=(0.0, 10.0))
     lode = @test_nowarn lodeproblem(timespan=(0.0, 10.0))
 
-    hode_sol = integrate(hode, ImplicitMidpoint())
-    lode_sol = integrate(lode, ImplicitMidpoint())
+    hode_sol = integrate_quietly(hode, ImplicitMidpoint())
+    lode_sol = integrate_quietly(lode, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1E-12
     @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1E-11
@@ -23,8 +25,8 @@ const OSS = OuterSolarSystem
     hode_sym = @test_nowarn hodeproblem(timespan=(0.0, 10.0), symbolic=true)
     lode_sym = @test_nowarn lodeproblem(timespan=(0.0, 10.0), symbolic=true)
 
-    hode_sym_sol = integrate(hode_sym, ImplicitMidpoint())
-    lode_sym_sol = integrate(lode_sym, ImplicitMidpoint())
+    hode_sym_sol = integrate_quietly(hode_sym, ImplicitMidpoint())
+    lode_sym_sol = integrate_quietly(lode_sym, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, hode_sym_sol.q) < 1E-12
     @test relative_maximum_error(hode_sol.p, hode_sym_sol.p) < 1E-11

--- a/test/perturbed_pendulum_tests.jl
+++ b/test/perturbed_pendulum_tests.jl
@@ -3,14 +3,16 @@ using GeometricIntegrators
 using GeometricProblems.PerturbedPendulum
 using GeometricSolutions
 
+include("integrate_quietly.jl")
+
 
 @testset "$(rpad("Perturbed Pendulum",80))" begin
 
     hode = @test_nowarn hodeproblem()
     lode = @test_nowarn lodeproblem()
 
-    hode_sol = integrate(hode, ImplicitMidpoint())
-    lode_sol = integrate(lode, ImplicitMidpoint())
+    hode_sol = integrate_quietly(hode, ImplicitMidpoint())
+    lode_sol = integrate_quietly(lode, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1e-12
     @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1e-12

--- a/test/poincare_invariants_tests.jl
+++ b/test/poincare_invariants_tests.jl
@@ -1,0 +1,61 @@
+using Test
+using PoincareInvariants
+
+import GeometricProblems
+import GeometricProblems.LotkaVolterra2d as lv2
+import GeometricProblems.LotkaVolterra2dGauge as lv2g
+import GeometricProblems.LotkaVolterra2dSingular as lv2si
+import GeometricProblems.LotkaVolterra2dSymmetric as lv2sy
+
+# Loading PoincareInvariants activates the `LotkaVolterra2dPoincareInvariants` extension. Its bodies
+# are dead — they call `PoincareInvariant1st`, which PoincareInvariants 0.5 does not define, and
+# `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are now `odeproblem`/`iodeproblem` — and
+# they stay that way until the Poincaré-invariant support gets its makeover.
+#
+# What is worth asserting in the meantime is that the extension still *resolves*: that it
+# precompiles, that Pkg attaches it, and that it reaches all four Lotka-Volterra 2d modules. Under
+# `Requires` none of that was checkable, and both call paths rotted through two renames unnoticed.
+# These tests are what makes the move to an extension pay for itself; they fail on a typo in the
+# `@eval` loop, on a renamed parent module, and on a `[weakdeps]`/`[extensions]` mismatch.
+
+const MODULES = (lv2, lv2g, lv2si, lv2sy)
+
+@testset "$(rpad("Poincaré invariants extension",80))" begin
+
+    @testset "extension is loaded" begin
+        ext = Base.get_extension(GeometricProblems, :LotkaVolterra2dPoincareInvariants)
+        @test ext !== nothing
+    end
+
+    @testset "methods are attached to all four modules" begin
+        for M in MODULES
+            @test !isempty(methods(M.ode_loop))
+            @test !isempty(methods(M.iode_loop))
+            @test !isempty(methods(M.ode_poincare_invariant_1st))
+            @test !isempty(methods(M.iode_poincare_invariant_1st))
+        end
+    end
+
+    # `f_loop` and `initial_conditions_loop` are deliberately *not* in the extension: they need
+    # nothing from PoincareInvariants, so they must work in a bare environment too. This asserts
+    # they are live methods rather than empty stubs.
+    @testset "loop sampling lives in the package, not the extension" begin
+        for M in MODULES
+            q₀ = M.initial_conditions_loop(8)
+            @test size(q₀) == (2, 8)
+            @test all(q₀[:, i] == M.f_loop(i, 8) for i in 1:8)
+        end
+    end
+
+    # Pin the dead paths to the error they currently throw, so that a repair — or an accidental
+    # revival against an interface that happens to fit — has to come past this test.
+    @testset "invariant bodies are still dead" begin
+        for M in MODULES
+            @test_throws UndefVarError M.ode_loop(4)
+            @test_throws UndefVarError M.iode_loop(4)
+            @test_throws UndefVarError M.ode_poincare_invariant_1st(0.01, 4, 10, 1)
+            @test_throws UndefVarError M.iode_poincare_invariant_1st(0.01, 4, 10, 1)
+        end
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,3 +96,6 @@ end
 @safetestset "Plotting extensions                                                             " begin
     include("plots_tests.jl")
 end
+@safetestset "Poincaré invariants extension                                                   " begin
+    include("poincare_invariants_tests.jl")
+end

--- a/test/three_body_tests.jl
+++ b/test/three_body_tests.jl
@@ -60,4 +60,16 @@ include("integrate_quietly.jl")
     h = integrate(hodeproblem(; timespan = (0.0, 0.05), timestep = 0.01, parameters = mparams), Gauss(2))
     l = integrate(lodeproblem(; timespan = (0.0, 0.05), timestep = 0.01, parameters = mparams), Gauss(2))
     @test relative_maximum_error(h.q, l.q) < 1E-6
+
+    # Positive control for `integrate_quietly`. The suite emits no SimpleSolvers messages at all, so
+    # the silence assertions elsewhere cannot themselves distinguish "quiet" from "the filter matches
+    # nothing" — were those messages to move out of the `SimpleSolvers` module, all 33 call sites
+    # would keep passing vacuously. This integration is known to complain: the collisional
+    # `sympnets_initial_condition` cannot be integrated past its close encounter at any step size
+    # (see `ThreeBody.DEFAULT_TIMESTEP`), so the same expression that asserts silence there must
+    # report messages here.
+    collisional = hodeproblem(ThreeBody.sympnets_initial_condition.q,
+        ThreeBody.sympnets_initial_condition.p;
+        timespan = (0.0, 1.0), timestep = 0.5)
+    @test !isempty(simplesolvers_messages(collisional, Gauss(2)))
 end

--- a/test/three_body_tests.jl
+++ b/test/three_body_tests.jl
@@ -2,6 +2,8 @@ using GeometricIntegrators: Gauss, integrate, relative_maximum_error
 using GeometricProblems.ThreeBody
 using Test
 
+include("integrate_quietly.jl")
+
 # Regression tests for the three-body problem:
 #  * the potential must contain all three pairwise gravitational interactions (previously the
 #    body-1↔body-3 term was missing);
@@ -32,8 +34,8 @@ using Test
 
     # both problem types construct and integrate (B4 regression: `lodeproblem` previously threw an
     # UndefVarError), and agree to roundoff over the default window.
-    hsol = integrate(hodeproblem(), Gauss(2))
-    lsol = integrate(lodeproblem(), Gauss(2))
+    hsol = integrate_quietly(hodeproblem(), Gauss(2))
+    lsol = integrate_quietly(lodeproblem(), Gauss(2))
 
     @test relative_maximum_error(hsol.q, lsol.q) < 1E-14
     @test relative_maximum_error(hsol.p, lsol.p) < 1E-14

--- a/test/toda_lattice_tests.jl
+++ b/test/toda_lattice_tests.jl
@@ -4,6 +4,8 @@ using GeometricProblems.TodaLattice
 using LinearAlgebra
 using Test
 
+include("integrate_quietly.jl")
+
 const TL = TodaLattice
 
 
@@ -29,8 +31,8 @@ param_vec = [NamedTuple{keys(params)}(values(params) .+ β) for β in -0.1 : 0.1
 hode_prb = hodeproblem(q₀, p₀)
 lode_prb = lodeproblem(q₀, p₀)
 
-href_sol = integrate(hode_prb, Gauss(1))
-lref_sol = integrate(lode_prb, Gauss(1))
+href_sol = integrate_quietly(hode_prb, Gauss(1))
+lref_sol = integrate_quietly(lode_prb, Gauss(1))
 
 @test relative_maximum_error(href_sol.q, lref_sol.q) < 2E-14
 
@@ -39,8 +41,8 @@ lref_sol = integrate(lode_prb, Gauss(1))
 hode_ens = hodeensemble(N, q₀_vec, p₀_vec)
 lode_ens = lodeensemble(N, q₀_vec, p₀_vec)
 
-hode_sol = integrate(hode_ens, Gauss(1))
-lode_sol = integrate(lode_ens, Gauss(1))
+hode_sol = integrate_quietly(hode_ens, Gauss(1))
+lode_sol = integrate_quietly(lode_ens, Gauss(1))
 
 @test relative_maximum_error(hode_sol[2].q, href_sol.q) < 2E-14
 @test relative_maximum_error(lode_sol[2].q, lref_sol.q) < 2E-14
@@ -54,8 +56,8 @@ end
 hode_ens = hodeensemble(N; parameters = param_vec)
 lode_ens = lodeensemble(N; parameters = param_vec)
 
-hode_sol = integrate(hode_ens, Gauss(1))
-lode_sol = integrate(lode_ens, Gauss(1))
+hode_sol = integrate_quietly(hode_ens, Gauss(1))
+lode_sol = integrate_quietly(lode_ens, Gauss(1))
 
 @test relative_maximum_error(hode_sol[2].q, href_sol.q) < 2E-14
 @test relative_maximum_error(lode_sol[2].q, lref_sol.q) < 2E-14
@@ -69,8 +71,8 @@ end
 hode_ens = hodeensemble(q₀_vec, p₀_vec; parameters = param_vec)
 lode_ens = lodeensemble(q₀_vec, p₀_vec; parameters = param_vec)
 
-hode_sol = integrate(hode_ens, Gauss(1))
-lode_sol = integrate(lode_ens, Gauss(1))
+hode_sol = integrate_quietly(hode_ens, Gauss(1))
+lode_sol = integrate_quietly(lode_ens, Gauss(1))
 
 @test relative_maximum_error(hode_sol[2].q, href_sol.q) < 2E-14
 @test relative_maximum_error(lode_sol[2].q, lref_sol.q) < 2E-14
@@ -225,8 +227,8 @@ end
     hode = hodeproblem(M, qM, pM; timespan = timespan, timestep = timestep)
     lode = lodeproblem(M, qM, pM; timespan = timespan, timestep = timestep)
 
-    hode_sol = integrate(hode, ImplicitMidpoint())
-    lode_sol = integrate(lode, ImplicitMidpoint())
+    hode_sol = integrate_quietly(hode, ImplicitMidpoint())
+    lode_sol = integrate_quietly(lode, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, lode_sol.q) < 1E-12
     @test relative_maximum_error(hode_sol.p, lode_sol.p) < 1E-11
@@ -236,8 +238,8 @@ end
     hode_sym = hodeproblem(M, qM, pM; timespan = timespan, timestep = timestep, symbolic = true)
     lode_sym = lodeproblem(M, qM, pM; timespan = timespan, timestep = timestep, symbolic = true)
 
-    hode_sym_sol = integrate(hode_sym, ImplicitMidpoint())
-    lode_sym_sol = integrate(lode_sym, ImplicitMidpoint())
+    hode_sym_sol = integrate_quietly(hode_sym, ImplicitMidpoint())
+    lode_sym_sol = integrate_quietly(lode_sym, ImplicitMidpoint())
 
     @test relative_maximum_error(hode_sol.q, hode_sym_sol.q) < 1E-12
     @test relative_maximum_error(hode_sol.p, hode_sym_sol.p) < 1E-11


### PR DESCRIPTION
GeometricIntegrators 0.17.0 requires SimpleSolvers 0.10 and GeometricIntegratorsBase 0.5.1.

**None of the breaking changes in that line reach this package.** `solversize`/`nullvectorsize` flipping to `(method, problem)` and `default_options` becoming a required two-argument method affect only code that defines or calls them; every call site here uses the positional `integrate(problem, method)` form, and `src/`/`ext/` contain no GeometricIntegrators or SimpleSolvers code at all. What changed is numerical and observational — and it invalidated three things the repository had written down.

### Bounds

`test/`, `docs/` and `examples/` had **no `[compat]` section at all**, so nothing constrained which GeometricIntegrators they resolved and they had drifted apart — 0.16.9, 0.16.7 and 0.16.2 respectively, the last with SimpleSolvers 0.8.4. All three now require `GeometricIntegrators = "0.17"`. As in GeometricIntegrators itself, the bound lives where the dependency is resolved rather than in the root project.

### Tolerances

GeometricIntegratorsBase 0.5.1 sets `f_abstol = max(8, solversize(method, problem)) * eps(datatype(problem))` where 0.16.x used a flat `8eps()`. **No test threshold needed re-tuning** — the tightest assertions keep at least a factor of five, and the figures the three-body docstring quotes are unmoved (energy error 2.66e-15 against a 1e-12 bound and a quoted "3e-15"; orbit closure 1.28e-7 against 1e-6 and a quoted "1.3e-7").

### Three-body warning counts

The `DEFAULT_TIMESTEP` docstring recorded 596, 1346, 390, 321 and 361 Newton warnings against 1–2 for `DogLeg`, to argue that the trust region was *merely quieter* about the same failure. Re-measured under 0.10 the counts are **5, 9, 4, 4, 4** and **6, 1, 1, 5, 6** — the asymmetry was an artefact of pre-`maxlog` reporting, so the count now measures how a failure is reported rather than how badly it fails.

Rewritten around the energy error instead: Newton 19, 15, 36, 399, 249; DogLeg 9, 45, 12, 1615, 2.2e6; the two ending 0.6, 3.8, 5.0, 50 and 1209 apart in `q`. On that quantity `DogLeg` is not merely no better but **worse** — by factors of 4 and 9e3 at the two finest step sizes, and better nowhere by more than a factor of 3 — which supports the original conclusion more strongly than the original wording did. The default Newton solver stays.

### Silence tripwire

`integrate_quietly` moved out of `eulerlagrange_ensembles_tests.jl` into `test/integrate_quietly.jl` and now also guards `three_body`, `toda_lattice`, `linear_wave`, `coupled_harmonic_oscillator`, `outer_solar_system` and `perturbed_pendulum` — 26 further call sites, 33 in total. It *asserts* silence rather than suppressing it, which is only meaningful from 0.10 on: before that a line search built its own `Options` and never saw the solver's `verbosity`.

`verbosity = 0` is **not** a substitute. Measured on the collisional three-body case it takes 5 messages to 2, not 0 — the iteration-count and hard-failure messages are ungated by design (`SimpleSolvers/src/nonlinear/nonlinear_solver_status.jl:346`). More to the point, suppressing would hide the regression this guards against: a stalled solve throws nothing and returns a solution, which is exactly what happened when `ThreeBody`'s default initial condition was still a member of the collisional grid.

Deliberately **not** applied to the SPARK and VPRK-projection suites or the unequal-mass three-body runs, where some tableaux are marginal and a stagnation warning is information rather than noise.

Two properties of the helper are worth stating:

- **It has a positive control.** Filtering by originating module (`nameof(l._module) === :SimpleSolvers`) makes that symbol load-bearing: were those messages to move module, the filter would match nothing and all 33 assertions would pass vacuously. Since the suite emits zero SimpleSolvers messages, no run of it can tell "silent" from "vacuous" on its own. The last test in `three_body_tests.jl` closes that: it integrates the collisional `sympnets_initial_condition` over `t ∈ [0, 1]` at `Δt = 0.5` and asserts the *same* expression reports something. It catches four distinct messages today — three line-search reports and one iteration-limit report — and fails if the filter ever stops matching.
- **It does not swallow anything else.** Records from every module other than SimpleSolvers are re-emitted to the enclosing logger, so applying the helper to a call site does not blind that site to unrelated warnings.

Module filtering is used rather than `@test_nowarn` both to ignore the unrelated `GeometricEquations` single-sample-ensemble warning and because SimpleSolvers must stay a transitive-only dependency.

### Poincaré invariants: `Requires` → extension

The first Poincaré invariant was the package's only use of `Requires`, so moving it to `ext/LotkaVolterra2dPoincareInvariants.jl` drops the dependency with it. **The code is still dead, deliberately**: it calls `PoincareInvariant1st`, removed in PoincareInvariants 0.5.0, on `lotka_volterra_2d_ode`/`lotka_volterra_2d_iode`, which are pre-0.7 constructor names. It is carried over unrepaired because the support needs a complete makeover and the upstream interface is still being tuned, so 0.5 is not the target to write against.

What the move buys is visibility — but only in an environment that has the trigger package, and nothing in the repository had one, which is exactly how both call paths rotted through two renames unnoticed. So `test/Project.toml` now lists PoincareInvariants purely as that trigger, and the new `test/poincare_invariants_tests.jl` asserts that the extension resolves, that Pkg attaches it, and that it reaches all four Lotka-Volterra 2d modules. It also pins the dead bodies to the `UndefVarError` they currently throw, so the makeover has to come past a test rather than around one.

`f_loop` and `initial_conditions_loop` stay in `src/` rather than moving with the invariants. They parameterise and sample the loop in phase space, they need nothing from PoincareInvariants, and `initial_conditions_loop` is the only part of the cluster that works — moving it would have turned a working call into a `MethodError` in every environment without the weakdep. `ode_loop`/`iode_loop` are dead for the same reason as the invariants and did move.

The root `[extras]` block is gone (there was no `[targets]`, and `test/Project.toml` takes precedence anyway). `PoincareInvariants` is a `[weakdeps]` entry bounded at `"0.4, 0.5"`: unlike `[extras]`, a weakdep bound is resolved and therefore enforced, and bounding to `"0.5"` alone would have excluded 0.4 — the last line the bodies would in fact run on — while admitting only the line they cannot.

### Docs

`docs/src/pendulum.md` no longer calls `Logging.disable_logging(Logging.Warn)`, which existed to hide the old flood and suppressed every warning on the page along with it.

### Examples

Seven scripts **added**: `lotka_volterra_2d{,_singular,_symmetric}.jl`, `lotka_volterra_{3d,4d}.jl`, `massless_charged_particle_2d.jl` and `point_vortices.jl`. Before this the directory held only `pendulum.jl` and `harmonic_oscillator.jl` — scripts for these seven problems existed as untracked local files, never committed, and had rotted against GeometricIntegrators years ago: `set_config`, `GeometricIntegrators.Integrators.VPRK`, the `getTableau*` factories, the `Integrator*` types, `Solution(ode, Δt, nt)` + `integrate!`, and `Plots` functions that no longer exist. Each was ~420 lines of which roughly four fifths was a commented-out tableau menu. Nothing would have caught that in any case: `examples/` is invisible to both `runtests.jl` and `docs/make.jl`.

The committed versions are written in the shape of `examples/pendulum.jl` as a table of `(name, problem, method)` runs, plotted with the Makie extension functions and saved as one PDF per run next to the script via `@__DIR__` — which is where `.gitignore` has expected them (`examples/*.pdf`) all along. Method/formulation pairings are taken from the corresponding test file, so they are known-good; all seven run and produce PDFs.

The five scratch variants (`lotka_volterra_2d_{debug,regression,simplified,test}.jl`, `harmonic_oscillator_legacy.jl`) remain untracked and broken, by decision.

## Verification

- Full suite green: **972 assertions across 33 testsets, 0 failures, 0 errors, 0 warnings from any module, 0 SimpleSolvers messages** — both standalone and under the pre-push `Pkg.test`.
- The Poincaré-invariant extension precompiles and loads in the test environment; its 41 assertions cover extension resolution, method attachment to all four modules, and the `UndefVarError` the dead bodies throw.
- Docs build exits 0; the only two warnings are Documenter housekeeping (figure-size fallback, local deploy skip).
- All seven examples run to completion, writing 36 PDFs into `examples/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
